### PR TITLE
Validation refactor

### DIFF
--- a/src/Message/Cog/Form/Handler.php
+++ b/src/Message/Cog/Form/Handler.php
@@ -387,7 +387,7 @@ class Handler
 
 			if(!$this->getPost()) {
 				$this->_valid = false;
-				
+
 				return $this->_valid;
 			}
 

--- a/src/Message/Cog/Validation/Validator.php
+++ b/src/Message/Cog/Validation/Validator.php
@@ -331,7 +331,6 @@ class Validator
 	{
 		// Check if data has been submitted
 		$notSet = empty($this->_data[$name]);
-//		d($name, $this->_data[$name]);
 
 		if ($notSet && !$field['optional']) {
 			$this->_messages->addError($name, $field['readableName'].' is a required field.');


### PR DESCRIPTION
Refactored validation to remove duplication, notably confusion regarding the difference between isValid() and getFilteredData(). The latter now calls isValid(), and there is a $_valid property that is set by isValid(), which it checks before running and logic, so a form is only validated once, regardless of which method you call first. Now the only real difference between these methods is that one returns a boolean and one returns an array.
