### PR TITLE
Bootstraps should be loaded recursively

### DIFF
--- a/src/Message/Cog/Application/Loader.php
+++ b/src/Message/Cog/Application/Loader.php
@@ -198,7 +198,8 @@ namespace Message\Cog\Application {
 
 			// Register the service for the bootstrap loader
 			$this->_services['bootstrap.loader'] = function($c) {
-				return new \Message\Cog\Bootstrap\Loader($c);
+				// Can not call $this->_services['filesystem.finder'] as it has not yet been created.
+				return new \Message\Cog\Bootstrap\Loader($c, new \Message\Cog\Filesystem\Finder());
 			};
 
 			// Load the Cog bootstraps

--- a/src/Message/Cog/Bootstrap/Loader.php
+++ b/src/Message/Cog/Bootstrap/Loader.php
@@ -16,6 +16,7 @@ use Message\Cog\HTTP\RequestAwareInterface;
 class Loader implements LoaderInterface
 {
 	protected $_services;
+	protected $_finder;
 	protected $_bootstraps = array();
 
 	/**
@@ -23,9 +24,10 @@ class Loader implements LoaderInterface
 	 *
 	 * @param ContainerInterface $container The service container
 	 */
-	public function __construct(ContainerInterface $container)
+	public function __construct(ContainerInterface $container, Finder $finder)
 	{
 		$this->_services = $container;
+		$this->_finder   = $finder;
 	}
 
 	/**
@@ -48,8 +50,7 @@ class Loader implements LoaderInterface
 		}
 
 		// Find all files in the path recursively
-		$finder = new Finder();
-		$finder->files()->in($path);
+		$finder = $this->_finder->files()->in($path);
 
 		foreach ($finder as $file) {
 			// Skip non-php files


### PR DESCRIPTION
So that cogules can group bootstraps with directories if they like.

It should also use the `Filesystem\Finder` rather than a straight up `DirectoryIterator`.

This will allow us to do #102.
