### PR TITLE
Displaying authorship users

### DIFF
--- a/src/Message/Cog/ValueObject/Authorship.php
+++ b/src/Message/Cog/ValueObject/Authorship.php
@@ -277,7 +277,6 @@ class Authorship
 
 		$this->_deletedAt = null;
 		$this->_deletedBy = null;
-		$this->_deletedUser = null;
 
 		return $this;
 	}


### PR DESCRIPTION
Authorship is defined within `cog`, and users within `cog-user`. For correct separation `cog` authorships should not directly reference users.

However we need to be able to get the name of the authorship user, for example in the `__toString()` method as brought up here https://github.com/messagedigital/cog-mothership-returns/issues/17.
