### PR TITLE
Set mysql connection to use php timezone

### DIFF
--- a/src/Message/Cog/DB/Adapter/MySQLi/Connection.php
+++ b/src/Message/Cog/DB/Adapter/MySQLi/Connection.php
@@ -46,6 +46,11 @@ class Connection implements ConnectionInterface
 		if(isset($this->_params['charset'])) {
 			$this->_handle->set_charset($this->_params['charset']);
 		}
+
+		// Set the timezone to match PHP's
+		$now = new \DateTime;
+		$offset = $now->format('P');
+		$this->query('SET time_zone="' . $offset . '";');
 	}
 
 	public function query($sql)


### PR DESCRIPTION
See http://www.sitepoint.com/synchronize-php-mysql-timezone-configuration/

Without this the mysql command `UNIX_TIMESTAMP()` may not match `time()` due to daylight savings / timezone differences.
