### PR TITLE
Add dev env email domain restriction to mailer

### DIFF
--- a/src/Message/Cog/Application/Bootstrap/Services.php
+++ b/src/Message/Cog/Application/Bootstrap/Services.php
@@ -643,6 +643,14 @@ class Services implements ServicesInterface
 			$transport = $c['mail.transport'];
 			$dispatcher = new \Message\Cog\Mail\Mailer($transport);
 
+			$dispatcher->setWhitelistFallback('dev@message.co.uk');
+			$dispatcher->addToWhitelist('/.+@message\.co\.uk/');
+
+			// Only enable whitelist filtering on non-live environments
+			if ($c['env']!== 'live') {
+				$dispatcher->enableToFiltering();
+			}
+
 			return $dispatcher;
 		});
 
@@ -666,13 +674,6 @@ class Services implements ServicesInterface
 
 			// Set default from address
 			$message->setFrom($c['cfg']->app->defaultEmailFrom->email, $c['cfg']->app->defaultEmailFrom->name);
-
-			// On non-live environments, set the default whitelist fallback, and
-			// only whitelist match as .*@message.co.uk
-			if ($c['env']!== 'live') {
-				$message->setWhitelistFallback('dev@message.co.uk');
-				$message->addToWhitelist('/.+@message\.co\.uk/');
-			}
 
 			return $message;
 		});

--- a/src/Message/Cog/Mail/Mailer.php
+++ b/src/Message/Cog/Mail/Mailer.php
@@ -4,4 +4,139 @@ namespace Message\Cog\Mail;
 
 class Mailer extends \Swift_Mailer
 {
+	protected $_whitelist = array();
+	protected $_whitelistFallback;
+	protected $_whitelistEnabled = false;
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function send(\Swift_Mime_Message $message, &$failedRecipients = null)
+    {
+    	if ($this->_whitelistEnabled) {
+	    	// Get the original 'to' addresses
+	    	$original = $message->getTo();
+
+	    	// Filter these against the whitelist
+	    	$addresses = $this->_whitelistFilter($original);
+
+	    	// Set the new 'to' addresses
+	    	$message->setTo($addresses);
+
+	    	// Only attach the 'Original-To' header if this email is only sending to
+			// the fallback, so we do not accidently share addresses with other
+			// users.
+			if (1 === count($addresses) and $this->_whitelistFallback === key($addresses)) {
+				$message->getHeaders()->addMailboxHeader(
+					'Original-To', $original
+				);
+			}
+	    }
+
+    	return parent::send($message, $failedRecipients);
+    }
+
+    /**
+     * Enable the whitelist filtering on 'to' addresses
+     *
+     * @return void
+     */
+    public function enableToFiltering()
+    {
+    	$this->_whitelistEnabled = true;
+    }
+
+    /**
+     * Disable the whitelist filtering on 'to' addresses
+     *
+     * @return void
+     */
+    public function disableToFiltering()
+    {
+    	$this->_whitelistEnabled = false;
+    }
+
+	/**
+	 * Set the fallback email address that is used when an address does not
+	 * match any whitelist options.
+	 *
+	 * @param  string $address
+	 * @return void
+	 */
+	public function setWhitelistFallback($address)
+	{
+		$this->_whitelistFallback = $address;
+	}
+
+	/**
+	 * Get the whitelist
+	 *
+	 * @return array
+	 */
+	public function getWhitelist()
+	{
+		return $this->_whitelist;
+	}
+
+	/**
+	 * Set the whitelist
+	 *
+	 * @param  array $walterWhite
+	 * @return void
+	 */
+	public function setWhitelist($walterWhite)
+	{
+		$this->_whitelist = $walterWhite;
+	}
+
+	/**
+	 * Add a regex test to the whitelist
+	 *
+	 * @param string $regex
+	 */
+	public function addToWhitelist($regex)
+	{
+		$regex = is_array($regex) ? $regex : array($regex);
+
+		$this->_whitelist = array_merge($this->_whitelist, $regex);
+	}
+
+	/**
+	 * Filter an array of addresses against the whitelist.
+	 *
+	 * @param  array $addresses
+	 * @return array
+	 */
+	protected function _whitelistFilter(array $addresses)
+	{
+		$filtered = array();
+
+		// If there are any whitelist tests
+		if (count($this->_whitelist) > 0) {
+
+			// Filter each address
+			foreach ($addresses as $address => $name) {
+				$matched = false;
+
+				// Check against each whitelist regex test
+				foreach ($this->_whitelist as $regex) {
+					$matched = (bool) preg_match($regex, $address);
+					if ($matched) break;
+				}
+
+				// If the address did not match any of the tests, replace it with
+				// the fallback address.
+				if (false === $matched) {
+					$address = $this->_whitelistFallback;
+				}
+
+				$filtered[$address] = $name;
+			}
+		}
+		else {
+			$filtered = $addresses;
+		}
+
+		return $filtered;
+	}
 }


### PR DESCRIPTION
When in a dev environment emails should only send to `*@message.co.uk` addresses. And any unrecognised ones should go to `dev@message.co.uk` with a note saying who it was originally for.
