### PR TITLE
Converted PDFs should recognise print styles

### DIFF
--- a/src/Message/Cog/Filesystem/Conversion/PDFConverter.php
+++ b/src/Message/Cog/Filesystem/Conversion/PDFConverter.php
@@ -39,6 +39,43 @@ class PDFConverter extends AbstractConverter implements CombinerInterface {
 		// Strip out `@font-face{ ... }` style tags as these break the pdf
 		$html = preg_replace('/@font-face{([^}]*)}/ms', '', $html);
 
+
+		// Remove wrapping `@media print { ... }` tag and braces. Print styles
+		// should be applied to PDFs but the media query will not be
+		// recognised.
+		$mediaTag = '@media print {';
+
+		// While there is a print media query found, get it's position
+		while (false !== $mediaPos = strpos($html, $mediaTag)) {
+
+			// We start with 1 opening pair belonging to the media query
+			$openPairs = 1;
+
+			// Loop each character after the media query tag, checking for
+			// braces and counting how many open pairs we currently have.
+			$chars = str_split($html);
+			for ($i = $mediaPos + strlen($mediaTag); $i < strlen($html); $i++) {
+				if ('{' == $chars[$i]) {
+					$openPairs++;
+				}
+				elseif ('}' == $chars[$i]) {
+					$openPairs--;
+				}
+
+				// If we have closed the media query brace pair, remove the
+				// tag and closing brace from the characters and implode these
+				// back into the html, ready to be checked again.
+				if (0 === $openPairs) {
+					unset($chars[$i]);
+					for ($j = $mediaPos; $j < $mediaPos + strlen($mediaTag); $j++) {
+						unset($chars[$j]);
+					}
+					$html = implode($chars);
+					break;
+				}
+			}
+		}
+
 		$pdf->generateFromHTML($html, $path);
 
 		return new File($path);


### PR DESCRIPTION
Anything within a `@media print { ... }` tag should be applied to the view before being converted to a pdf.