### PR TITLE
Making Twig auto escape strategy based on view format

### DIFF
--- a/src/Message/Cog/Application/Bootstrap/Services.php
+++ b/src/Message/Cog/Application/Bootstrap/Services.php
@@ -157,6 +157,23 @@ class Services implements ServicesInterface
 					'cache'       => 'cog://tmp',
 					'auto_reload' => true,
 					'debug'       => 'live' !== $c['env'],
+					'autoescape'  => function($name) {
+						// Trim off the .twig file extension
+						if ('.twig' === substr($name, -5)) {
+							$name = substr($name, 0, -5);
+						}
+
+						// Get the actual file extension (format)
+						$format = substr($name, strrpos($name, '.') + 1);
+
+						// If the format is html, css or js, set that as the autoescape strategy
+						if (in_array($format, array('html', 'js', 'css'))) {
+							return $format;
+						}
+
+						// Otherwise, turn off autoescaping (for example, .txt files for plaintext emails)
+						return false;
+					}
 				)
 			);
 


### PR DESCRIPTION
See https://github.com/messagedigital/cog/pull/274 which I accidentally created for the wrong branch GARGHH.

Should resolve this issue: https://trello.com/c/luTqOORJ/360-urgent-fix-outbound-emails-on-all-emails-coming-directly-from-the-website-the-apostrophe-is-converted-to-the-coding-for-an-apost
