### PR TITLE
Remove/abstract up() and down() methods from base Migration class

### DIFF
--- a/src/Migration/Adapter/MySQL/Migration.php
+++ b/src/Migration/Adapter/MySQL/Migration.php
@@ -4,7 +4,8 @@ namespace Message\Cog\Migration\Adapter\MySQL;
 
 use Message\Cog\Migration\Adapter\MigrationInterface;
 
-abstract class Migration implements MigrationInterface {
+abstract class Migration implements MigrationInterface
+{
 
 	protected $_query;
 	protected $_file;


### PR DESCRIPTION
Not sure what the benefit is in having two blank `up()` and `down()` methods in the base Migration class is, as it seems to defeat the point of having it implement the MigrationInterface, and all Migrations are going to need a `down()` method that reverts the `up()`
