### PR TITLE
Migrations: Unneccessary error on first run of migrate:install

### DIFF
--- a/src/Console/Command/MigrateRun.php
+++ b/src/Console/Command/MigrateRun.php
@@ -40,7 +40,8 @@ class MigrateRun extends Command
 				$this->get('migration')->run($reference);
 			}
 			catch (\Message\Cog\DB\Exception $e) {
-				throw new \Exception("Migration error: Have you run `migrate:install`?", null, $e);
+				$output->writeln('<error>Migration error: Have you run `migrate:install`?</error>');
+				return;
 			}
 
 			// Output this migration's notes


### PR DESCRIPTION
When running migrate:install for the first time on a fresh DB, you get this output:

![screenshot 2013-12-10 16 53 16](https://f.cloud.github.com/assets/2511043/1716073/a63a7c3c-61bb-11e3-9740-7ae122172a09.png)

Only the first error need show. And it should be caught and properly output using `<error>` tag wrapping.
