### PR TITLE
Minor form handler refactor and adding default values to datalist

### DIFF
--- a/resources/view/form/twig/form_div_layout.html.twig
+++ b/resources/view/form/twig/form_div_layout.html.twig
@@ -244,7 +244,7 @@
 
 {% block datalist_widget %}
 	{% spaceless %}
-		<input id="{{ id }}" name="{{ full_name }}" list="{{ id }}list" {{ block('widget_attributes') }}>
+		<input id="{{ id }}" name="{{ full_name }}" list="{{ id }}list" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %}>
 		<datalist id="{{ id }}list">
 			{% for choice in choices %}
 				<option value="{{ choice }}">

--- a/src/Form/Handler.php
+++ b/src/Form/Handler.php
@@ -90,6 +90,13 @@ class Handler
 	 */
 	protected $_fields = array();
 
+	/**
+	 * @var \Symfony\Component\Form\FormFactory
+	 */
+	protected $_factory;
+
+	protected $_initialised	= false;
+
 
 	/**
 	 * Creates instance of SymfonyForm and Validator on construction
@@ -137,7 +144,10 @@ class Handler
 	 */
 	public function setDefaultValues($values)
 	{
-		$this->_defaultValues = (array)$values;
+		if ($this->_initialised) {
+			throw new \Exception('You cannot add default values to an initialised form!');
+		}
+		$this->_defaultValues = (array) $values;
 
 		return $this;
 	}
@@ -403,6 +413,7 @@ class Handler
 	protected function _initialiseForm()
 	{
 		$form = $this->_factory->createNamed($this->_name, 'form', $this->_defaultValues, $this->_options);
+		$this->_initialised	= true;
 
 		return $form;
 	}


### PR DESCRIPTION
- Throw an exception in the form handler if you're trying to add default values to a form that's already been initialised
- Also the $_factory property is used but it wasn't defined in the class so I fixed that
- Also the datalist form field wasn't pulling default values so I fixed that too
