### PR TITLE
Entity Choice List bug

### DIFF
--- a/src/Form/Extension/Core/ChoiceList/EntityChoiceList.php
+++ b/src/Form/Extension/Core/ChoiceList/EntityChoiceList.php
@@ -53,9 +53,7 @@ class EntityChoiceList extends ObjectChoiceList
 
 		foreach ($choices as $i => $givenChoice) {
 			foreach ($this->getChoices() as $j => $choice) {
-				if ($givenChoice && $this->_propertyAccessor->getValue($givenChoice, $this->_identifier)
-					=== $this->_propertyAccessor->getValue($choice, $this->_identifier)) {
-
+				if ($this->areChoicesEqual($givenChoice, $choice)) {
 					$values[$i] = $this->getValues()[$j];
 					unset($choices[$i]);
 
@@ -79,9 +77,7 @@ class EntityChoiceList extends ObjectChoiceList
 
 		foreach ($choices as $i => $givenChoice) {
 			foreach ($this->getChoices() as $j => $choice) {
-				if ($givenChoice && $this->_propertyAccessor->getValue($givenChoice, $this->_identifier)
-					=== $this->_propertyAccessor->getValue($choice, $this->_identifier)) {
-
+				if ($this->areChoicesEqual($givenChoice, $choice)) {
 					$indices[$i] = $j;
 					unset($choices[$i]);
 
@@ -93,5 +89,21 @@ class EntityChoiceList extends ObjectChoiceList
 		}
 
 		return $indices;
+	}
+
+	/**
+	 * Method comparing two choices.
+	 *
+	 * @param  mixed   $choice1   First choice
+	 * @param  mixed   $choice2   Second choice
+	 * @return boolean            True if the first and second choice have the same
+	 *                            $_identifier-property (and are therefore considered equal).
+	 */
+	protected function areChoicesEqual($choice1, $choice2)
+	{
+		// make sure both choices are not null, then compare their values
+		return $choice1 && $choice2
+			&& $this->_propertyAccessor->getValue($choice1, $this->_identifier)
+			=== $this->_propertyAccessor->getValue($choice2, $this->_identifier);
 	}
 }


### PR DESCRIPTION
#### What does this do?

There was a bug caused by us using `$_choices` instead of `Symfony\Component\Form\Extension\Core\ChoiceList\ChoiceList::choices` (accessed via `$this->getChoices()`). It is only a problem when using a non-numeric property as value for the choice list, which we haven't really done before, but need to do with collections.

I removed the `$_choices`-property and while having a look at Symfony's Choice List, realised there is a second method that compares choices (namely `getIndicesForChoices()`), so I overrode it and made it use our compare-logic.
#### How should this be manually tested?

The only place we currently use this is in the return section in epos:
- Go to your union copy(`/lewes/1/return/order/113/item`), chose an item.
- On the next page, chose a reason <-- this is where we use the associative array in the entity type
#### Related PRs / Issues / Resources?

_n/a_
#### Anything else to add? (Screenshots, background context, etc)

_n/a_
