### PR TITLE
Adding event attach functionality to DB transaction

### DIFF
--- a/src/Application/Bootstrap/Services.php
+++ b/src/Application/Bootstrap/Services.php
@@ -48,8 +48,8 @@ class Services implements ServicesInterface
 		// shortcut for easier access
 		$services['db'] = $services->raw('db.query');
 
-		$services['db.transaction'] = $services->factory(function($s) {
-			return new Cog\DB\Transaction($s['db.connection']);
+		$services['db.transaction'] = $services->factory(function($c) {
+			return new Cog\DB\Transaction($c['db.connection'], $c['event.dispatcher']);
 		});
 
 		$services['db.nested_set_helper'] = $services->factory(function($s) {

--- a/src/DB/Transaction.php
+++ b/src/DB/Transaction.php
@@ -4,30 +4,79 @@ namespace Message\Cog\DB;
 
 use Message\Cog\DB\Adapter\ConnectionInterface;
 
+use Message\Cog\Event\DispatcherInterface;
+use Message\Cog\Event\Event;
+
 /**
-*
-*/
+ * A transaction is a collection of queries that run one after another as a
+ * batch. If an error occurs while executing them, all of the queries in the
+ * transaction are rolled back. This helps prevent malformed databases.
+ */
 class Transaction implements QueryableInterface
 {
-	protected $_query;
 	protected $_connection;
-	protected $_queries = array();
+	protected $_query;
+	protected $_queries = [];
 
-	public function __construct(ConnectionInterface $connection)
+	protected $_eventDispatcher;
+	protected $_events = [];
+
+	/**
+	 * Constructor
+	 *
+	 * @param ConnectionInterface $connection The database connection to use
+	 * @param DispatcherInterface $dispatcher The event dispatcher to use
+	 */
+	public function __construct(ConnectionInterface $connection, DispatcherInterface $dispatcher)
 	{
-		$this->_connection = $connection;
+		$this->_eventDispatcher = $dispatcher;
+		$this->_connection      = $connection;
+
 		$this->_query = new Query($connection);
 		$this->_query->fromTransaction = true;
 	}
 
-	public function add($query, $params = array())
+	/**
+	 * Attach an event to the database transaction. The event will be dispatched
+	 * after the query has been committed, assuming the transaction was not
+	 * rolled back.
+	 *
+	 * If the transaction was rolled back, no events are dispatched.
+	 *
+	 * It is also possible to pass a Closure in for the second parameter
+	 * `$event`. This closure will be given this transaction as the first and
+	 * only parameter, and must return an instance of Event. The closure is
+	 * executed just before the event is dispatched.
+	 *
+	 * @param  string         $name  The name of the event to dispatch
+	 * @param  Event|\Closure $event The event object to dispatch, or a closure
+	 *                               that returns the event object
+	 *
+	 * @return Transaction           Returns $this for chainability
+	 */
+	public function attachEvent($name, $event)
 	{
-		$this->_queries[] = array($query, $params);
+		if (!($event instanceof Event)
+		 && !($event instanceof \Closure)) {
+			throw new \InvalidArgumentException('Cannot attach event: expected Event or Closure instance');
+		}
+
+		$this->_events[] = [
+			'name'  => $name,
+			'event' => $event,
+		];
 
 		return $this;
 	}
 
-	public function run($query, $params = array())
+	public function add($query, $params = [])
+	{
+		$this->_queries[] = [$query, $params];
+
+		return $this;
+	}
+
+	public function run($query, $params = [])
 	{
 		return $this->add($query, $params);
 	}
@@ -40,16 +89,38 @@ class Transaction implements QueryableInterface
 	public function commit()
 	{
 		$this->_query->run($this->_connection->getTransactionStart());
+
 		try {
-			foreach($this->_queries as $query) {
+			foreach ($this->_queries as $query) {
 				$this->_query->run($query[0], $query[1]);
 			}
-		} catch(Exception $e) {
+		} catch (Exception $e) {
 			$this->rollback();
 			throw $e;
 		}
 
-		return $this->_query->run($this->_connection->getTransactionEnd());
+		$return = $this->_query->run($this->_connection->getTransactionEnd());
+
+		$this->_dispatchEvents();
+
+		$this->reset();
+
+		return $return;
+	}
+
+	/**
+	 * Reset the transaction to an empty state.
+	 *
+	 * All events and queries are removed.
+	 *
+	 * @return Transaction Returns $this for chainability
+	 */
+	public function reset()
+	{
+		$this->_events  = [];
+		$this->_queries = [];
+
+		return $this;
 	}
 
 	public function setIDVariable($name)
@@ -65,5 +136,22 @@ class Transaction implements QueryableInterface
 	public function getID()
 	{
 		return $this->_query->run("SELECT ".$this->_connection->getLastInsertIdFunc())->value();
+	}
+
+	/**
+	 * Dispatch all events set on this transaction.
+	 *
+	 * Any event definitions that were passed in as closures are executed, and
+	 * the result is dispatched.
+	 */
+	protected function _dispatchEvents()
+	{
+		foreach ($this->_events as $event) {
+			$eventInstance = ($event['event'] instanceof \Closure)
+				? $event['event']($this)
+				: $event['event'];
+
+			$this->_eventDispatcher->dispatch($event['name'], $eventInstance);
+		}
 	}
 }


### PR DESCRIPTION
#### What does this do?

Allows you to attach events to a database transaction which then dispatches them only when the transaction is committed.
#### How should this be manually tested?

Set up some code to try attaching events to a transaction, check they are only dispatched on `commit()`
#### Related PRs / Issues / Resources?

Closes #337 
#### Anything else to add? (Screenshots, background context, etc)

N/a
