### PR TITLE
Field groups contextual help fix

### DIFF
--- a/src/Field/BaseField.php
+++ b/src/Field/BaseField.php
@@ -149,6 +149,7 @@ abstract class BaseField implements FieldInterface, FieldContentInterface
 	public function setTranslationKey($key)
 	{
 		$this->_translationKey = $key . '.' . $this->getName();
+		$this->_setHelpAttribute();
 	}
 
 	public function getFormType()
@@ -169,20 +170,12 @@ abstract class BaseField implements FieldInterface, FieldContentInterface
 	 */
 	protected function _getHelpKeys()
 	{
-		$className = strtolower(get_class($this));
-		$className = trim(strrchr($className, '\\'), '\\');
-
 		return $this->_translationKey . '.help';
 	}
 
 	protected function _setHelpAttribute()
 	{
-		if (empty($options['attr'])) {
-			$this->_options['attr'] = [];
-		}
-		if (empty($options['attr']['data-help-key'])) {
-			$this->_options['attr']['data-help-key'] = $this->_getHelpKeys();
-		}
+		$this->_options['attr']['data-help-key'] = $this->_getHelpKeys();
 	}
 
 	/**


### PR DESCRIPTION
#### What does this do?

Fixes messagedigital/cog-mothership-cms#197. The problem was, that the contextual help key was not set when the translation key was added, but only in the constructor (when the translation key is still `null`).
To fix this, I have added a call to `_setHelpAttribute()` in the `setTranslationKey()`-method.

I also removed a few lines of code that we don't actually need.
#### How should this be manually tested?

Better test this on UW, we don't have many contextual help keys for groups defined on UMS! Go through a few pages, make sure all defined help keys work (for groups and normal fields!).
#### Related PRs / Issues / Resources?

Issue: messagedigital/cog-mothership-cms#197
#### Anything else to add? (Screenshots, background context, etc)
