### PR TITLE
Escape form value in twig ext

### DIFF
--- a/resources/view/form/twig/form_div_layout.html.twig
+++ b/resources/view/form/twig/form_div_layout.html.twig
@@ -13,7 +13,10 @@
 {% block form_widget_simple %}
 	{% spaceless %}
 		{% set type = type|default('text') %}
-		<input type="{{ type }}" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %}/>
+		{# `value` is parsed through Twig's `escape` filter. Symfony form doesn't do this by default, and so it seems
+		 very possible to me that the value is supposed to be filtered elsewhere. see https://github.com/messagedigital/cog/issues/370
+		  for the issue #}
+		<input type="{{ type }}" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value | escape}}" {% endif %}/>
 	{% endspaceless %}
 {% endblock form_widget_simple %}
 


### PR DESCRIPTION
A quick fix for issue where the forms were producing invalid HTML as a result of not escaping the values.

This can be tested by saving a value to a text field with a `"` in it. See https://github.com/messagedigital/cog/issues/370
