### PR TITLE
Remove call to setContainer() on Field\Factory

### DIFF
--- a/src/Field/Factory.php
+++ b/src/Field/Factory.php
@@ -156,10 +156,6 @@ class Factory implements \IteratorAggregate, \Countable
 
 		$field->setTranslationKey($this->_baseTransKey);
 
-		if ($field instanceof ContainerAwareInterface) {
-			$field->setContainer($this->_services);
-		}
-
 		return $field;
 	}
 


### PR DESCRIPTION
#### What does this do?

Removes a call to `setContainer()` from `Field\Factory` as the service container was removed in https://github.com/messagedigital/cog/commit/cb95e99966c2788644e770da05ca15cfaab66580
#### How should this be manually tested?

I can't really think of a particularly good way to test it. This change shouldn't break anything that wasn't already broken (I don't believe we actually use any of the fields that are container aware)
#### Related PRs / Issues / Resources?
#### Anything else to add? (Screenshots, background context, etc)
