### PR TITLE
Update version requirement for SwiftMailer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
 		"lmammino/jsmin4assetic"           : "1.0.*",
 		"natxet/CssMin"                    : "3.0.*",
 		"filp/whoops"                      : "1.0.*",
-		"swiftmailer/swiftmailer"          : "~5.0",
+		"swiftmailer/swiftmailer"          : "~5.2.1 | ~5.3",
 		"knplabs/knp-snappy"               : "0.1.*",
 		"message/wkhtmltopdf"              : "1.0.*",
 		"itbz/fpdf"                        : "1.7.*",

--- a/composer.lock
+++ b/composer.lock
@@ -3,7 +3,7 @@
         "This file locks the dependencies of your project to a known state",
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
     ],
-    "hash": "75b112fcca08b6d7637080c4e628a811",
+    "hash": "2d3a3999a1067b70bf09d79b354bca8e",
     "packages": [
         {
             "name": "dflydev/markdown",


### PR DESCRIPTION
#### What does this do?

Updates the version requirement for SwiftMailer to allow new sub-versions which means we can now have the security fix as deatailed in #374.
#### How should this be manually tested?

Composer install on this branch. Check SwiftMailer is >=v5.2.1
#### Related PRs / Issues / Resources?

Closes #374
#### Anything else to add? (Screenshots, background context, etc)
