### PR TITLE
translations folder no longer required

### DIFF
--- a/src/Localisation/Translator.php
+++ b/src/Localisation/Translator.php
@@ -66,8 +66,10 @@ class Translator extends BaseTranslator implements ContainerAwareInterface
 
 			// Load application translation files
 			$dir = $this->_container['app.loader']->getBaseDir().'translations';
-			foreach ($this->_container['filesystem.finder']->in($dir) as $file) {
-				$this->addResource('yml', $file->getPathname(), $file->getFilenameWithoutExtension());
+			if (file_exists($dir)){	
+				foreach ($this->_container['filesystem.finder']->in($dir) as $file) {
+					$this->addResource('yml', $file->getPathname(), $file->getFilenameWithoutExtension());
+				}
 			}
 
 			parent::loadCatalogue($locale);


### PR DESCRIPTION
#### What does this do?

Removes the need for a translations folder to exist
#### How should this be manually tested?

Remove translations folder from a site and check to see if it still loads
#### Related PRs / Issues / Resources?

Original issue: https://github.com/messagedigital/cog/issues/363
#### Anything else to add? (Screenshots, background context, etc)
