### PR TITLE
Added alias functions for dumping queries

### DIFF
--- a/src/Application/Loader.php
+++ b/src/Application/Loader.php
@@ -38,7 +38,7 @@ namespace {
 	 */
 	function dQueries()
 	{
-		d(\Message\Cog\Service\Container::get('db.query')->getQueryList());
+		return d(\Message\Cog\Service\Container::get('db.query')->getQueryList());
 	}
 
 	/**
@@ -49,7 +49,7 @@ namespace {
 	 */
 	function deQueries()
 	{
-		de(\Message\Cog\Service\Container::get('db.query')->getQueryList());
+		return de(\Message\Cog\Service\Container::get('db.query')->getQueryList());
 	}
 }
 


### PR DESCRIPTION
#### What does this do?

An enhancement on this: https://github.com/messagedigital/cog/pull/351, which stores all the queries that are run in a static variable, and adds a method for getting all of them. Unfortunately, the way you get these from the `index.php` (where you're most likely to want to use it) is long and hard to remember:

``` php
\Message\Cog\Service\Container::get('db.query')->getQueryList()
```

This PR adds a couple global functions, `dQueries()` and `deQueries()`, that basically do a dump/dump and exit on the result of this method call.
#### How should this be manually tested?

In your `public/index.php` file, call these methods and ensure they dump out a bunch of queries. To test whether or not they exit, echo out some HTML afterwards, `deQueries()` should not render it, where `dQueries()` should
#### Related PRs / Issues / Resources?
#### Anything else to add? (Screenshots, background context, etc)
