### PR TITLE
Can set html attributes to raw in form fields

### DIFF
--- a/resources/view/form/twig/form_div_layout.html.twig
+++ b/resources/view/form/twig/form_div_layout.html.twig
@@ -406,8 +406,32 @@
 
 {% block widget_attributes %}
 	{% spaceless %}
-		id="{{ id }}" name="{{ full_name }}"{% if read_only %} readonly="readonly"{% endif %}{% if disabled %} disabled="disabled"{% endif %}{% if required %} required="required"{% endif %}{% if max_length %} maxlength="{{ max_length }}"{% endif %}{% if pattern %} pattern="{{ pattern }}"{% endif %}
-		{% for attrname, attrvalue in attr %}{% if attrname in ['placeholder', 'title'] %}{{ attrname }}="{{ attrvalue|trans({}, translation_domain) }}" {% else %}{{ attrname }}="{{ attrvalue|escape('html_attr') }}" {% endif %}{% endfor %}
+		id="{{ id }}"
+		name="{{ full_name }}"
+		{% if read_only %}
+			readonly="readonly"
+		{% endif %}
+		{% if disabled %}
+			disabled="disabled"
+		{% endif %}
+		{% if required %}
+			required="required"
+		{% endif %}
+		{% if max_length %}
+			maxlength="{{ max_length }}"
+		{% endif %}
+		{% if pattern %}
+			pattern="{{ pattern }}"
+		{% endif %}
+		{% for attrname, attrvalue in attr %}
+			{% if attrname in ['placeholder', 'title'] %}
+				{{ attrname }}="{{ attrvalue|trans({}, translation_domain) }}"
+			{% elseif attrname in raw %}
+				{{ attrname }}="{{ attrvalue|raw }}"
+			{% else %}
+				{{ attrname }}="{{ attrvalue|escape('html_attr') }}"
+			{% endif %}
+		{% endfor %}
 	{% endspaceless %}
 {% endblock widget_attributes %}
 


### PR DESCRIPTION
#### What does this do?

Allows you to use `raw` HTML attributes. The twig form view is set up to escape attribute values, and rightly so, but in some scenarios you don't want to do that, specifically when setting the attribute value as something that will be used by JavaScript.

It's probably more often than not a design flaw elsewhere if we need to do this, but still we often do this and since switching auto escaping back on (https://github.com/messagedigital/cog/pull/387), it places where this has happened.

To use this, you will need to pass in an array called `raw` to the form field in the view, containing all the custom attributes you want to escape:

```
{{
    form_row(form.field, {
        'attr': { 'some-data-attribute': '#value' },
        'raw': {0: 'some-data-attribute'}
    })
}}
```

Annoyingly, you have to set a key on Twig arrays so the `0` is necessary (although it can theoretically be whatever you want)
#### How should this be manually tested?

Set an attribute on a form field and give the name of the field to the `raw` array. For an example it is used here:
https://github.com/messagedigital/uniform_wares/commit/46f96ca98582695d869dbd3bf1e9f3bbe2be014f
#### Related PRs / Issues / Resources?
#### Anything else to add? (Screenshots, background context, etc)
