### PR TITLE
Command migrate:run to soft error if class not found

### DIFF
--- a/src/Migration/Adapter/MySQL/Loader.php
+++ b/src/Migration/Adapter/MySQL/Loader.php
@@ -103,12 +103,17 @@ class Loader implements LoaderInterface {
 
 	public function resolve(File $file, $reference)
 	{
-		// Load the migration class
-		include_once $file->getRealpath();
-
-		// Get the class name
+		$path = $file->getRealpath();
 		$classname = str_replace('.php', '', $file->getBasename());
 
+		if (!file_exists($path)) {
+			return null;
+		}
+
+		// Load the migration class
+		include_once $path;
+
+		// Get the class name
 		return new $classname($reference, $file, $this->_connector);
 	}
 


### PR DESCRIPTION
#### What does this do?

Makes migrate:run not break if a class isn't found.
#### How should this be manually tested?

Run migrate:run on a site where it would normally break. Errors should still occur, but the migration should complete.
#### Related PRs / Issues / Resources?
#### Anything else to add? (Screenshots, background context, etc)
