### PR TITLE
Binding results to objects now works with setter methods too

### DIFF
--- a/src/DB/Result.php
+++ b/src/DB/Result.php
@@ -325,9 +325,17 @@ class Result extends ResultArrayAccess
 
 	protected function _bindPropertiesToObject($subject, $data, $force)
 	{
-		foreach($data as $key => $value) {
+		foreach ($data as $key => $value) {
 			if (property_exists($subject, $key) || $force) {
 				$subject->{$key} = $value;
+			}
+			elseif (method_exists($subject, 'set' . ucfirst($key))) {
+				try {
+					call_user_func([$subject, 'set' . ucfirst($key)], $value);
+				}
+				catch (\Exception $e) {
+					// do nothing
+				}
 			}
 		}
 	}


### PR DESCRIPTION
#### What does this do?

Allows the `bind` family of methods on the `DB\Result` object to check for setter methods when building objects. It will not break the script if it cannot set the value, so this allows for type hinted values
#### How should this be manually tested?

Check that objects can be loaded with values from the database bound via the setters. Since this is such a low level addition, it will need to be tested thoroughly to check nothing breaks, although since most of the older objects have primarily public properties, they don't tend to have setters. Also if they ARE public, it won't use the setter anyway.
#### Related PRs / Issues / Resources?
#### Anything else to add? (Screenshots, background context, etc)
