### PR TITLE
Feature/multiple currencies

### DIFF
--- a/src/Templating/Twig/Extension/PriceTwigExtension.php
+++ b/src/Templating/Twig/Extension/PriceTwigExtension.php
@@ -42,8 +42,9 @@ class PriceTwigExtension extends \Twig_Extension
      */
     public function currencySymbolFunction($currency = null, $locale= null)
     {
- 		$locale = ($locale == null ? \Locale::getDefault() : $locale);
- 		$formatter = new \NumberFormatter($locale, \NumberFormatter::CURRENCY);
+        $locale = ($locale == null ? \Locale::getDefault() : $locale);
+        $formatter = new \NumberFormatter($locale, \NumberFormatter::CURRENCY);
+        $currency = $currency?:$this->_defaultCurrency;
 
         $symbol = substr($formatter->formatCurrency(0, $currency), 0, -4);
 


### PR DESCRIPTION
#### What does this do?

Allows a default currency to be given ad set on the Price twig extension. 
#### How should this be manually tested?

Try putting default currencies when initialising in the service. Try using the setDefaultCurrency method too.
#### Related PRs / Issues / Resources?
#### Anything else to add? (Screenshots, background context, etc)
