### PR TITLE
Allow translations on captcha form labels

### DIFF
--- a/src/Application/Bootstrap/Services.php
+++ b/src/Application/Bootstrap/Services.php
@@ -168,7 +168,7 @@ class Services implements ServicesInterface
 					'auto_reload' => true,
 					'debug'       => 'live' !== $c['env'],
 					'autoescape'  => function($name) {
-						
+
 						// Trim off the .twig file extension
 						if ('.twig' === substr($name, -5)) {
 							$name = substr($name, 0, -5);
@@ -518,7 +518,7 @@ class Services implements ServicesInterface
 
 		$services['form.extensions'] = function($c) {
 			return [
-				new \Message\Cog\Form\Extension\Core\CoreExtension($c['http.session'], $c['cfg']),
+				new \Message\Cog\Form\Extension\Core\CoreExtension($c['http.session'], $c['cfg'], $c['translator']),
 				new \Symfony\Component\Form\Extension\Core\CoreExtension,
 				new \Symfony\Component\Form\Extension\Csrf\CsrfExtension(
 					new \Symfony\Component\Form\Extension\Csrf\CsrfProvider\SessionCsrfProvider($c['http.session'], $c['form.csrf_secret'])

--- a/src/Form/Extension/Core/CoreExtension.php
+++ b/src/Form/Extension/Core/CoreExtension.php
@@ -4,6 +4,7 @@ namespace Message\Cog\Form\Extension\Core;
 
 use Message\Cog\HTTP\Session;
 use Message\Cog\Config\Registry;
+use Message\Cog\Localisation\Translator;
 
 use Symfony\Component\Form\AbstractExtension;
 
@@ -11,11 +12,13 @@ class CoreExtension extends AbstractExtension
 {
 	protected $_session;
 	protected $_cfg;
+	protected $_trans;
 
-	public function __construct(Session $session, Registry $cfg)
+	public function __construct(Session $session, Registry $cfg, Translator $trans)
 	{
 		$this->_session = $session;
 		$this->_cfg     = $cfg;
+		$this->_trans   = $trans;
 	}
 
 	protected function loadTypes()
@@ -23,7 +26,7 @@ class CoreExtension extends AbstractExtension
 		return [
 			new Type\DatalistType,
 			new Type\EntityType,
-			new Type\CaptchaType($this->_cfg->captcha->textcaptchaKey, $this->_session)
+			new Type\CaptchaType($this->_cfg->captcha->textcaptchaKey, $this->_session, $this->_trans)
 		];
 	}
 

--- a/src/Form/Extension/Core/Type/CaptchaType.php
+++ b/src/Form/Extension/Core/Type/CaptchaType.php
@@ -4,6 +4,7 @@ namespace Message\Cog\Form\Extension\Core\Type;
 
 use Message\Cog\Http\Session;
 use Message\Cog\Form\Extension\Core\EventListener\CaptchaEventListener;
+use Message\Cog\Localisation\Translator;
 
 use Symfony\Component\Validator\Constraints;
 use Symfony\Component\Form;
@@ -16,16 +17,18 @@ class CaptchaType extends Form\AbstractType
 
 	protected $_key;
 	protected $_session;
+	protected $_trans;
 
 	protected $_fallback = [
 		'question' => 'What colour is the sky?',
 		'answer'   => 'blue',
 	];
 
-	public function __construct($apiKey, Session $session)
+	public function __construct($apiKey, Session $session, Translator $trans)
 	{
 		$this->_key     = $apiKey;
 		$this->_session = $session;
+		$this->_trans   = $trans;
 	}
 
 	public function getName()
@@ -40,7 +43,7 @@ class CaptchaType extends Form\AbstractType
 
 	public function buildView(Form\FormView $view, Form\FormInterface $form, array $options)
 	{
-		$view->vars['label'] = ($options['label'] ? $options['label'] . ': ' : '') . $this->_getQuestion();
+		$view->vars['label'] = ($options['label'] ? $this->_trans->trans($options['label']) . ': ' : '') . $this->_getQuestion();
 	}
 
 	public function buildForm(Form\FormBuilderInterface $builder, array $options)


### PR DESCRIPTION
#### What does this do?

Allows translations to be used on Captcha form fields (worth bearing in mind that the questions are still in English but oh well)
#### How should this be manually tested?

Check out https://github.com/messagedigital/cog-mothership-cms/pull/235 and use comment form
#### Related PRs / Issues / Resources?
#### Anything else to add? (Screenshots, background context, etc)
