### PR TITLE
Set default view namespace

### DIFF
--- a/src/Application/Bootstrap/Services.php
+++ b/src/Application/Bootstrap/Services.php
@@ -427,7 +427,10 @@ class Services implements ServicesInterface
 		};
 
 		$services['reference_parser'] = function($c) {
-			return new Cog\Module\ReferenceParser($c['module.locator'], $c['fns.utility']);
+			return new Cog\Module\ReferenceParser(
+				$c['module.locator'],
+				$c['fns.utility']
+			);
 		};
 
 		// Filesystem
@@ -731,7 +734,7 @@ class Services implements ServicesInterface
 		};
 
 		$services['asset.factory'] = function($c) {
-			$factory = new Cog\AssetManagement\Factory('cog://public/');
+			$factory = new Cog\AssetManagement\Factory(/*'cog://public/', */$c['app.loader']->getDefaultViewNamespace());
 
 			$factory->setReferenceParser($c['reference_parser']);
 			$factory->setFilterManager($c['asset.filters']);

--- a/src/Application/Bootstrap/Services.php
+++ b/src/Application/Bootstrap/Services.php
@@ -734,7 +734,7 @@ class Services implements ServicesInterface
 		};
 
 		$services['asset.factory'] = function($c) {
-			$factory = new Cog\AssetManagement\Factory(/*'cog://public/', */$c['app.loader']->getDefaultViewNamespace());
+			$factory = new Cog\AssetManagement\Factory('cog://public/', $c['app.loader']->getDefaultViewNamespace());
 
 			$factory->setReferenceParser($c['reference_parser']);
 			$factory->setFilterManager($c['asset.filters']);

--- a/src/Application/Bootstrap/Services.php
+++ b/src/Application/Bootstrap/Services.php
@@ -139,7 +139,8 @@ class Services implements ServicesInterface
 					'twig',
 					'php',
 				),
-				$c['templating.formats']
+				$c['templating.formats'],
+				$c['app.loader']->getDefaultViewNamespace()
 			);
 
 			$parser->addDefaultDirectory($c['app.loader']->getBaseDir() . 'view/');
@@ -168,7 +169,7 @@ class Services implements ServicesInterface
 					'auto_reload' => true,
 					'debug'       => 'live' !== $c['env'],
 					'autoescape'  => function($name) {
-						
+
 						// Trim off the .twig file extension
 						if ('.twig' === substr($name, -5)) {
 							$name = substr($name, 0, -5);

--- a/src/Application/Bootstrap/Services.php
+++ b/src/Application/Bootstrap/Services.php
@@ -144,7 +144,7 @@ class Services implements ServicesInterface
 					'php',
 				),
 				$c['templating.formats'],
-				$c['app.loader']->getDefaultViewNamespace()
+				$c['app.loader']->getDefaultNamespace()
 			);
 
 			$parser->addDefaultDirectory($c['app.loader']->getBaseDir() . 'view/');
@@ -734,7 +734,7 @@ class Services implements ServicesInterface
 		};
 
 		$services['asset.factory'] = function($c) {
-			$factory = new Cog\AssetManagement\Factory('cog://public/', $c['app.loader']->getDefaultViewNamespace());
+			$factory = new Cog\AssetManagement\Factory('cog://public/', $c['app.loader']->getDefaultNamespace());
 
 			$factory->setReferenceParser($c['reference_parser']);
 			$factory->setFilterManager($c['asset.filters']);

--- a/src/Application/Loader.php
+++ b/src/Application/Loader.php
@@ -165,7 +165,7 @@ namespace Message\Cog\Application {
 
 		/**
 		 * Return a representation of the default namespace for loading view files. If a view file does not exist, it will
-		 * look within its own namespace (as is standard behaviour in Cog 3.5 and under)
+		 * look within its own namespace (as is standard behaviour in earlier versions of Cog)
 		 *
 		 * @return string | null
 		 */

--- a/src/Application/Loader.php
+++ b/src/Application/Loader.php
@@ -169,7 +169,7 @@ namespace Message\Cog\Application {
 		 *
 		 * @return string | null
 		 */
-		public function getDefaultViewNamespace()
+		public function getDefaultNamespace()
 		{
 			return null;
 		}
@@ -364,8 +364,8 @@ namespace Message\Cog\Application {
 		 */
 		protected function _setDefaults()
 		{
-			// this will default the timezone to UTC if not set. Suppress as 
-			// otherwise date_default_timezone_get() gives strict warning if 
+			// this will default the timezone to UTC if not set. Suppress as
+			// otherwise date_default_timezone_get() gives strict warning if
 			// timezone not set
 			@date_default_timezone_set(date_default_timezone_get());
 		}

--- a/src/Application/Loader.php
+++ b/src/Application/Loader.php
@@ -164,6 +164,17 @@ namespace Message\Cog\Application {
 		}
 
 		/**
+		 * Return a representation of the default namespace for loading view files. If a view file does not exist, it will
+		 * look within its own namespace (as is standard behaviour in Cog 3.5 and under)
+		 *
+		 * @return string | null
+		 */
+		public function getDefaultViewNamespace()
+		{
+			return null;
+		}
+
+		/**
 		 * Set the service container to use.
 		 *
 		 * This gets set automatically, so this method is only for overriding the

--- a/src/AssetManagement/Factory.php
+++ b/src/AssetManagement/Factory.php
@@ -10,6 +10,8 @@ class Factory extends AssetFactory
 	protected $_cacheBustingEnabled = false;
 	protected $_parsed = array();
 
+	private $_defaultNamespace;
+
 	public function __construct($root, $defaultNamespace, $debug = false)
 	{
 		parent::__construct($root, $debug);
@@ -162,7 +164,7 @@ class Factory extends AssetFactory
 
 	private function _convertRelativePaths(array $inputs)
 	{
-		if (null !== $this->_defaultNamespace) {
+		if (null === $this->_defaultNamespace) {
 			return $inputs;
 		}
 

--- a/src/AssetManagement/Factory.php
+++ b/src/AssetManagement/Factory.php
@@ -15,7 +15,10 @@ class Factory extends AssetFactory
 	public function __construct($root, $defaultNamespace, $debug = false)
 	{
 		parent::__construct($root, $debug);
-		$this->_defaultNamespace = $defaultNamespace;
+
+		if (null !== $defaultNamespace) {
+			$this->_defaultNamespace = str_replace('\\', ':', trim($defaultNamespace, '\\'));
+		}
 	}
 
 	public function setReferenceParser($referenceParser)

--- a/src/AssetManagement/Factory.php
+++ b/src/AssetManagement/Factory.php
@@ -161,7 +161,14 @@ class Factory extends AssetFactory
 		return $parsed;
 	}
 
-
+	/**
+	 * If a default namespace is set, it will convert relative asset paths to that of the default namespace, and if the file
+	 * exists, it will swap it out for the existing asset
+	 *
+	 * @param array $inputs
+	 *
+	 * @return array
+	 */
 	private function _convertRelativePaths(array $inputs)
 	{
 		if (null === $this->_defaultNamespace) {

--- a/src/AssetManagement/FileReferenceAsset.php
+++ b/src/AssetManagement/FileReferenceAsset.php
@@ -5,6 +5,7 @@ namespace Message\Cog\AssetManagement;
 use Message\Cog\Module\ReferenceParserInterface;
 
 use Assetic\Asset\FileAsset;
+use Assetic\Util\VarUtils;
 
 /**
  * Asset for a file using a Cog reference. The reference is parsed before it is
@@ -31,6 +32,6 @@ class FileReferenceAsset extends FileAsset
 	{
 		$source = $parser->parse($source)->getFullPath();
 
-		return parent::__construct($source, $filters, $sourceRoot, $sourcePath, $vars);
+		parent::__construct($source, $filters, $sourceRoot, $sourcePath, $vars);
 	}
 }

--- a/src/Module/Locator.php
+++ b/src/Module/Locator.php
@@ -26,7 +26,8 @@ class Locator implements LocatorInterface
 	/**
 	 * Gets the path to the module directory.
 	 *
-	 * @param  string $moduleName Module name (e.g. Message\Raven)
+	 * @param string $moduleName Module name (e.g. Message\Raven)
+	 * @param bool $inLibrary
 	 *
 	 * @return string             The path to the module directory
 	 *

--- a/src/Templating/ViewNameParser.php
+++ b/src/Templating/ViewNameParser.php
@@ -5,6 +5,7 @@ namespace Message\Cog\Templating;
 use Message\Cog\Service\ContainerInterface;
 use Message\Cog\Module\ReferenceParserInterface;
 use Message\Cog\Filesystem\Finder;
+use Message\Cog\Module\ReferenceParser;
 
 use Symfony\Component\Templating\TemplateReference;
 use Symfony\Component\Templating\TemplateNameParser;
@@ -71,7 +72,6 @@ class ViewNameParser extends TemplateNameParser
 	 *
 	 * @param string $reference  The view reference (without the format)
 	 * @param bool   $batch      Return a batch of templates
-	 * @param bool  $useDefault  Attempt to use default view namespace if no namespace is set on view
 	 *
 	 * @return string            The view file path
 	 *
@@ -97,7 +97,9 @@ class ViewNameParser extends TemplateNameParser
 	/**
 	 * Get the absolute path for a parsed reference.
 	 *
-	 * @param  ReferenceParser $parsed Parsed reference
+	 * @param $reference
+	 * @param ReferenceParser $parsed Parsed reference
+	 *
 	 * @return ReferenceParser         Absolute parsed reference
 	 */
 	public function getAbsolute($reference, $parsed)

--- a/src/Templating/ViewNameParser.php
+++ b/src/Templating/ViewNameParser.php
@@ -20,19 +20,31 @@ class ViewNameParser extends TemplateNameParser
 	protected $_lastAbsoluteModule;
 	protected $_defaultDirs = array();
 
+	private $_setLastAbsolute = true;
+	private $_defaultViewNamespace;
+
 	/**
 	 * Constructor.
 	 *
-	 * @param ReferenceParserInterface $parser    Reference parser class
-	 * @param array                    $fileTypes Array of filetypes to support, in order of preference
-	 * @param array                    $fileTypes Array of formats to support, in order of preference
+	 * @param ReferenceParserInterface $parser       Reference parser class
+	 * @param Finder $finder
+	 * @param array $fileTypes                      $fileTypes Array of filetypes to support, in order of preference
+	 * @param array $formats                        $fileTypes Array of formats to support, in order of preference
+	 * @param string | null $defaultViewNamespace
 	 */
-	public function __construct(ReferenceParserInterface $parser, Finder $finder, array $fileTypes, array $formats)
+	public function __construct(
+		ReferenceParserInterface $parser,
+		Finder $finder,
+		array $fileTypes,
+		array $formats,
+		$defaultViewNamespace
+	)
 	{
 		$this->_parser    = $parser;
 		$this->_finder    = $finder;
 		$this->_fileTypes = $fileTypes;
 		$this->_formats   = $formats;
+		$this->_setDefaultViewNamespace($defaultViewNamespace);
 	}
 
 	/**
@@ -59,6 +71,7 @@ class ViewNameParser extends TemplateNameParser
 	 *
 	 * @param string $reference  The view reference (without the format)
 	 * @param bool   $batch      Return a batch of templates
+	 * @param bool  $useDefault  Attempt to use default view namespace if no namespace is set on view
 	 *
 	 * @return string            The view file path
 	 *
@@ -74,6 +87,51 @@ class ViewNameParser extends TemplateNameParser
 			return $reference;
 		}
 
+		if (null !== $this->_defaultViewNamespace && preg_match('/^\:\:.+/', $reference)) {
+			return $this->_parseWithDefaultViewNamespace($reference, $batch);
+		}
+
+		return $this->_parseWithReference($reference, $batch);
+	}
+
+	/**
+	 * Get the absolute path for a parsed reference.
+	 *
+	 * @param  ReferenceParser $parsed Parsed reference
+	 * @return ReferenceParser         Absolute parsed reference
+	 */
+	public function getAbsolute($reference, $parsed)
+	{
+		// If it is relative and an absolute path was used previously, make the
+		// reference absolute using the previous module name
+		// This is a fix for https://github.com/messagedigital/cog/issues/40
+		// which should be improved/refactored at a later date
+		if ($parsed->isRelative() && $this->_lastAbsoluteModule) {
+			// If it is relative, make it absolute with the last module name
+			$referenceSeparator = constant(get_class($this->_parser) . '::SEPARATOR');
+			$newReference = str_replace('\\', $referenceSeparator, $this->_lastAbsoluteModule) . $reference;
+
+			// Parse the new reference
+			$parsed = $this->_parser->parse($newReference);
+		}
+		else if (!$parsed->isRelative() && $this->_setLastAbsolute) {
+			$this->_lastAbsoluteModule = $parsed->getModuleName();
+		}
+
+		return $parsed;
+	}
+
+	/**
+	 * @param $reference
+	 * @param $batch
+	 * @param bool $setLastAbsolute
+	 * @throws \Symfony\Component\HttpKernel\Exception\NotAcceptableHttpException
+	 *
+	 * @return array|TemplateReference
+	 */
+	private function _parseWithReference($reference, $batch, $setLastAbsolute = true)
+	{
+		$setLastAbsolute = (bool) $setLastAbsolute;
 		$parsed = $this->_parser->parse($reference);
 
 		$referenceSeparator = constant(get_class($this->_parser) . '::SEPARATOR');
@@ -89,7 +147,7 @@ class ViewNameParser extends TemplateNameParser
 			// Parse the new reference
 			$parsed = $this->_parser->parse($newReference);
 		}
-		else if (!$parsed->isRelative()) {
+		else if (!$parsed->isRelative() && $setLastAbsolute) {
 			$this->_lastAbsoluteModule = $parsed->getModuleName();
 		}
 
@@ -147,31 +205,37 @@ class ViewNameParser extends TemplateNameParser
 	}
 
 	/**
-	 * Get the absolute path for a parsed reference.
+	 * Attempt to parse the namespace with the default view namespace appended. If it fails, parse the reference
+	 * normally
 	 *
-	 * @param  ReferenceParser $parsed Parsed reference
-	 * @return ReferenceParser         Absolute parsed reference
+	 * @param $reference
+	 * @param $batch
+	 *
+	 * @return string
 	 */
-	public function getAbsolute($reference, $parsed)
+	private function _parseWithDefaultViewNamespace($reference, $batch)
 	{
-		// If it is relative and an absolute path was used previously, make the
-		// reference absolute using the previous module name
-		// This is a fix for https://github.com/messagedigital/cog/issues/40
-		// which should be improved/refactored at a later date
-		if ($parsed->isRelative() && $this->_lastAbsoluteModule) {
-			// If it is relative, make it absolute with the last module name
-			$referenceSeparator = constant(get_class($this->_parser) . '::SEPARATOR');
-			$newReference = str_replace('\\', $referenceSeparator, $this->_lastAbsoluteModule) . $reference;
+		$amendedRef = $this->_defaultViewNamespace . $reference;
 
-			// Parse the new reference
-			$parsed = $this->_parser->parse($newReference);
+		try {
+			$this->_setLastAbsolute = false;
+			return $this->_parseWithReference($amendedRef, $batch, false);
+		} catch (NotAcceptableHttpException $e) {
+			$this->_setLastAbsolute = true;
+			return $this->_parseWithReference($reference, $batch, true);
 		}
-		else if (!$parsed->isRelative()) {
-			$this->_lastAbsoluteModule = $parsed->getModuleName();
-		}
-
-		return $parsed;
 	}
 
+	/**
+	 * @param null | string $namespace
+	 * @throws \InvalidArgumentException
+	 */
+	private function _setDefaultViewNamespace($namespace)
+	{
+		if (null !== $namespace && !is_string($namespace)) {
+			throw new \InvalidArgumentException('Default view namespace must be either null or a string, ' . gettype($namespace) . ' given');
+		}
 
+		$this->_defaultViewNamespace = $namespace;
+	}
 }


### PR DESCRIPTION
#### What does this do?

Allows a default view namespace to be set in the `App` class, making it easier to override views, particularly template views. It will first assume that a relative view path, i.e. one that has the format of `::path:to:view`, uses the default view namespace. If the view cannot be found, it will revert to its current behaviour - it will check the most recently used namespace that has been declared within a view and try and find it that way. If it still cannot find it, it will throw an exception as it does currently.
#### How should this be manually tested?

In a Mothership project, edit the `App.php` file so the class has `getDefaultViewNamespace()` method, which returns the view namespace of the main site codebase, e.g.:

``` php
<?php

class App extends \Message\Cog\Application\Loader
{
    protected function _registerModules()
    {
        return array(
            'Message\\ImageResize',
            'Message\\User',
            'Message\\Mothership\\User',
            'Message\\Mothership\\ControlPanel',
            'Message\\Mothership\\FileManager',
            'Message\\Mothership\\CMS',
            'Message\\Mothership\\Commerce',
            'Message\\Mothership\\Ecommerce',
            'Message\\Mothership\\OrderReturn',
            'Message\\Mothership\\Epos',
            'Message\\Mothership\\Voucher',
            'Message\\Mothership\\Discount',
            'Message\\Mothership\\Mailing',
            'Message\\Mothership\\Report',
            'Message\\Mothership\\Stripe',
            'Mothership\\Site',
        );
    }

    public function getDefaultViewNamespace()
    {
        return 'Mothership\\Site';
    }
}
```

Then look for a view override (there are plenty in Ecommerce' checkout) and move it to the main view directory of the project (for instance, you could move `/view/Message:Mothership:Ecommerce/checkout/checkout-layout.html.twig` to `/app/general/resources/view/checkout/checkout-layout.html.twig`). Doing this will still not work, as this PR only _sets up_ the capability of overriding views in this way. You will need to edit a view that references this view, for instance the `stage-1-review.html.twig` view in Ecommerce, and remove the namespace from the `extends` statement, so instead of having:

``` twig
{% extends 'Message:Mothership:Ecomerce::checkout:checkout-layout' %}
```

you will have

``` twig
{% extends '::checkout:checkout-layout' %}
```

This will automatically look for a view with a reference of `Mothership:Site::checkout:checkout-layout`, which can be found in the `resources/views/checkout` directory of the main project.

You should then check that it does not error if you remove this view, but rather renders the default view in Ecommerce (the one that has no styling)

In a Mothership module, change one of the view extends to use a relative path reference.

This change also works with asset paths. If you add a 'test.js' file in both a module and in the site itself, and link to it in a view within the module using `@::assets:js:test.js`, it should first look within the declared namespace for the asset file, and if it can't find it, default to the namespace of the module it is called from.
#### Related PRs / Issues / Resources?
#### Anything else to add? (Screenshots, background context, etc)
