### PR TITLE
Set umask to 0 before running asset tasks

### DIFF
--- a/src/AssetManagement/EventListener.php
+++ b/src/AssetManagement/EventListener.php
@@ -65,7 +65,9 @@ class EventListener extends BaseListener implements SubscriberInterface
 			), 'twig');
 		}
 
+		$oldUmask = umask(0);
 		$this->_services['asset.writer']->writeManagerAssets($this->_services['asset.manager']);
+		umask($oldUmask);
 	}
 
 	/**

--- a/src/Console/Command/AssetDump.php
+++ b/src/Console/Command/AssetDump.php
@@ -52,6 +52,7 @@ class AssetDump extends Command
 
 		$output->writeln('<info>Moving public assets for ' . count($modules) . ' modules.</info>');
 
+		$oldUmask = umask(0);
 		foreach($modules as $module) {
 			$moduleName = str_replace("\\", ':', $module);
 
@@ -87,6 +88,7 @@ class AssetDump extends Command
 				$fileSystem->mirror($originDir, $targetDir);
 			}
 		}
+		umask($oldUmask);
 
 		$output->writeln("<info>Finished dumping module assets.</info>");
 	}

--- a/src/Console/Command/AssetGenerator.php
+++ b/src/Console/Command/AssetGenerator.php
@@ -53,6 +53,8 @@ class AssetGenerator extends Command
 
 		$output->writeln('<info>Generating public assets for ' . count($modules) . ' modules.</info>');
 
+		$oldUmask = umask(0);
+
 		// Compile assets for all cogules
 		foreach ($modules as $module) {
 			$moduleName = str_replace("\\", ':', $module);
@@ -94,6 +96,8 @@ class AssetGenerator extends Command
 				), 'twig');
 			}
 		}
+
+		umask($oldUmask);
 
 		// Compile the assets
 		$this->_services['asset.writer']->writeManagerAssets($this->_services['asset.manager']);


### PR DESCRIPTION
#### What does this do?
Sets the `umask` of the PHP configuration to 0 before running tasks that involve setting permissions on directories.

The reason this is necessary is that sometimes PHP will try to set a permission on a directory to 0777 but because of what I can only describe as reasons, it will set the permissions to something like 0755. Setting the umask and then resetting ensures that the correct permissions are set (assuming PHP has permission to edit the permissions)

See: http://stackoverflow.com/questions/3997641/why-cant-php-create-a-directory-with-777-permissions

#### How should this be manually tested?
Empty the `public/assets` and `public/cogules` folders and run `bin/cog asset:dump` and `bin/cog asset:generate`. They should a) not break and b) be the correct permissions

#### Related PRs / Issues / Resources?

#### Anything else to add? (Screenshots, background context, etc)
