### PR TITLE
Feature/default timezone

### DIFF
--- a/src/Application/Loader.php
+++ b/src/Application/Loader.php
@@ -352,7 +352,12 @@ namespace Message\Cog\Application {
 		 * date_default_timezone_set('Europe/London');
 		 */
 		protected function _setDefaults()
-		{}
+		{
+			// this will default the timezone to UTC if not set. Suppress as 
+			// otherwise date_default_timezone_get() gives strict warning if 
+			// timezone not set
+			@date_default_timezone_set(date_default_timezone_get());
+		}
 
 		/**
 		 * Returns an array of modules to load. Defined by installation application


### PR DESCRIPTION
This makes it so that sites don't default to Europe/London anymore, yet still have their timezone set so no strict warns. This should be fixed if [this RFC](https://wiki.php.net/rfc/date.timezone_warning_removal) passes
