### PR TITLE
Adds 'certs' to the list of acceptable Cog file streams

### DIFF
--- a/src/Application/Bootstrap/Services.php
+++ b/src/Application/Bootstrap/Services.php
@@ -451,6 +451,7 @@ class Services implements ServicesInterface
 				"/^\/view/us"             => $baseDir.'view/',
 				"/^\/migrations\/(.*)/us" => $baseDir.'migrations/$1',
 				"/^\/migrations/us"       => $baseDir.'migrations/',
+				"/^\/certs(\/.*)?$/us"    => $baseDir.'certs$1',
 			);
 
 			return $mapping;

--- a/src/Filesystem/StreamWrapper.php
+++ b/src/Filesystem/StreamWrapper.php
@@ -72,10 +72,11 @@ class StreamWrapper implements StreamWrapperInterface
 	 *
 	 * Mappings are checked first, if there's no matching mapping then the reference parser is checked.
 	 *
-	 * @param  string $uri 		The uri to be parsed
+	 * @param  string $uri 		       The uri to be parsed
+	 * @param  string | bool $prefix
 	 *
-	 * @return string|boolean   If a valid URI is passed in, returns the full
-	 *                          real path to the file, otherwise false.
+	 * @return string|boolean          If a valid URI is passed in, returns the full
+	 *                                 real path to the file, otherwise false.
 	 */
 	public function getLocalPath($uri, $prefix = false)
 	{


### PR DESCRIPTION
#### What does this do?

Allow file paths that start with 'cog://certs'
#### How should this be manually tested?
#### Related PRs / Issues / Resources?
#### Anything else to add? (Screenshots, background context, etc)
