### PR TITLE
Config option to disable automatic asset regeneration

### DIFF
--- a/resources/fixtures/config/asset.yml
+++ b/resources/fixtures/config/asset.yml
@@ -1,0 +1,1 @@
+auto-generate: false

--- a/src/Application/Bootstrap/Events.php
+++ b/src/Application/Bootstrap/Events.php
@@ -73,9 +73,11 @@ class Events implements EventsInterface, ContainerAwareInterface
 		$eventDispatcher->addSubscriber(new \Message\Cog\Controller\EventListener);
 
 		// Asset Management
-		if (isset($this->_services['cfg']->assets) && $this->_services['cfg']->assets->autoGenerate) {
-			$eventDispatcher->addSubscriber(new \Message\Cog\AssetManagement\EventListener);
-		}
+		$eventDispatcher->addSubscriber(new \Message\Cog\AssetManagement\EventListener(
+			isset($this->_services['cfg']->assets) && isset($this->_services['cfg']->assets->autoGenerate) ? [
+				'auto-generate' => $this->_services['cfg']->assets->autoGenerate,
+			] : null)
+		);
 
 		// Migrations
 		$eventDispatcher->addSubscriber(new \Message\Cog\Migration\EventListener);

--- a/src/Application/Bootstrap/Events.php
+++ b/src/Application/Bootstrap/Events.php
@@ -73,7 +73,9 @@ class Events implements EventsInterface, ContainerAwareInterface
 		$eventDispatcher->addSubscriber(new \Message\Cog\Controller\EventListener);
 
 		// Asset Management
-		$eventDispatcher->addSubscriber(new \Message\Cog\AssetManagement\EventListener);
+		if (isset($this->_services['cfg']->assets) && $this->_services['cfg']->assets->autoGenerate) {
+			$eventDispatcher->addSubscriber(new \Message\Cog\AssetManagement\EventListener);
+		}
 
 		// Migrations
 		$eventDispatcher->addSubscriber(new \Message\Cog\Migration\EventListener);

--- a/src/Application/Bootstrap/Events.php
+++ b/src/Application/Bootstrap/Events.php
@@ -73,11 +73,7 @@ class Events implements EventsInterface, ContainerAwareInterface
 		$eventDispatcher->addSubscriber(new \Message\Cog\Controller\EventListener);
 
 		// Asset Management
-		$eventDispatcher->addSubscriber(new \Message\Cog\AssetManagement\EventListener(
-			isset($this->_services['cfg']->assets) && isset($this->_services['cfg']->assets->autoGenerate) ? [
-				'auto-generate' => $this->_services['cfg']->assets->autoGenerate,
-			] : null)
-		);
+		$eventDispatcher->addSubscriber(new \Message\Cog\AssetManagement\EventListener);
 
 		// Migrations
 		$eventDispatcher->addSubscriber(new \Message\Cog\Migration\EventListener);

--- a/src/AssetManagement/EventListener.php
+++ b/src/AssetManagement/EventListener.php
@@ -52,7 +52,7 @@ class EventListener extends BaseListener implements SubscriberInterface
 			return;
 		}
 
-		if ('local' !== $this->_services['env'] || $this->get('cfg')->asset->autoGenerate) {
+		if ('local' !== $this->_services['env'] || !$this->get('cfg')->asset->autoGenerate) {
 			return;
 		}
 

--- a/src/AssetManagement/EventListener.php
+++ b/src/AssetManagement/EventListener.php
@@ -20,19 +20,6 @@ use Message\Cog\AssetManagement\TwigResource;
  */
 class EventListener extends BaseListener implements SubscriberInterface
 {
-	private $_config = [];
-
-	public function __construct($config = null)
-	{
-		if (is_array($config)) {
-			$this->_config['auto-generate'] = $config['auto-generate'];
-		} else {
-			$this->_config = [
-				'auto-generate' => false,
-			];
-		}
-	}
-
 	/**
 	 * {@inheritdoc}
 	 */
@@ -65,7 +52,7 @@ class EventListener extends BaseListener implements SubscriberInterface
 			return;
 		}
 
-		if ('local' !== $this->_services['env'] || !$this->_config['auto-generate']) {
+		if ('local' !== $this->_services['env'] || $this->get('cfg')->asset->autoGenerate) {
 			return;
 		}
 

--- a/src/AssetManagement/EventListener.php
+++ b/src/AssetManagement/EventListener.php
@@ -20,6 +20,19 @@ use Message\Cog\AssetManagement\TwigResource;
  */
 class EventListener extends BaseListener implements SubscriberInterface
 {
+	private $_config = [];
+
+	public function __construct($config = null)
+	{
+		if (is_array($config)) {
+			$this->_config['auto-generate'] = $config['auto-generate'];
+		} else {
+			$this->_config = [
+				'auto-generate' => false,
+			];
+		}
+	}
+
 	/**
 	 * {@inheritdoc}
 	 */
@@ -52,7 +65,7 @@ class EventListener extends BaseListener implements SubscriberInterface
 			return;
 		}
 
-		if ('local' !== $this->_services['env']) {
+		if ('local' !== $this->_services['env'] || !$this->_config['auto-generate']) {
 			return;
 		}
 


### PR DESCRIPTION
## Why

Adds the ability to disable the autogeneration of assets. On local we currently regenerate assets on every request which can slow down our local versions of mothership. This should go some way to fixing that.

## Testing

To test add `asset.yml` config with `auto-generate: false`.