### PR TITLE
Fix buggy migrations

### DIFF
--- a/src/Migration/Adapter/LoaderInterface.php
+++ b/src/Migration/Adapter/LoaderInterface.php
@@ -16,4 +16,6 @@ interface LoaderInterface
 
 	public function resolve(File $file, $reference);
 
+	public function getFailures();
+
 }

--- a/src/Migration/Migrator.php
+++ b/src/Migration/Migrator.php
@@ -3,6 +3,7 @@
 namespace Message\Cog\Migration;
 
 use Message\Cog\Migration\Adapter\MigrationInterface;
+use Message\Cog\Filesystem\File;
 
 use Exception;
 
@@ -53,6 +54,8 @@ class Migrator {
 
 		// Run the collection
 		$this->_runCollection();
+
+		$this->_displayFailures();
 	}
 
 	/**
@@ -95,6 +98,8 @@ class Migrator {
 		foreach ($migrations as $migration) {
 			$this->_runDown($migration);
 		}
+
+		$this->_displayFailures();
 
 		return count($migrations);
 	}
@@ -219,6 +224,25 @@ class Migrator {
 	protected function _note($note)
 	{
 		$this->_notes[] = $note;
+	}
+
+	private function _displayFailures()
+	{
+		$failures = $this->_loader->getFailures();
+
+		if (!empty($failures) && !is_array($failures)) {
+			throw new \InvalidArgumentException('Cannot display failed migrations, migration failures expected as an array, got ' . (gettype($failures) === 'object') ? get_class($failures) : gettype($failures));
+		} elseif (empty($failures)) {
+			return false;
+		}
+
+		foreach ($failures as $failure) {
+			if (!is_string($failure)) {
+				throw new \InvalidArgumentException('Cannot display failed migrations, expected a string, got ' . (gettype($failure) === 'object') ? get_class($failure) : gettype($failure));
+			}
+
+			$this->_note('<error>Could not load migration: `' . $failure . '`</error>');
+		}
 	}
 
 }


### PR DESCRIPTION
#### What does this do?

Fixes and cleans up the migration process:
- Removed constructor from LoaderInterface
- Logs failures within the MySQL loader, and adds a `getFailures()` method to the interface
- Displays failures after running migrations
- Type hints arguments on Loader
- Creates a clone of the Finder class for every migration, to stop it from attempting to run migrations from within other modules - see https://github.com/messagedigital/cog/issues/326
#### How should this be manually tested?

Run migrations on a fresh installation
#### Related PRs / Issues / Resources?
#### Anything else to add? (Screenshots, background context, etc)
