### PR TITLE
Some RNG enhancements

### DIFF
--- a/src/Security/StringGenerator.php
+++ b/src/Security/StringGenerator.php
@@ -148,12 +148,14 @@ class StringGenerator
 			throw new \RuntimeException('Function `openssl_random_pseudo_bytes` does not exist.');
 		}
 
+		$rounds = 0;
 		do {
 			$random = openssl_random_pseudo_bytes($length);
 
 			$string = substr(base64_encode($random), 0, $length);
 			$string = str_replace('+', '.', rtrim($string, '='));
-		} while (!preg_match($this->_pattern, $string));
+			++$rounds;
+		} while (!preg_match($this->_pattern, $string) && $rounds < $length);
 		
 
 		return $string;
@@ -173,13 +175,15 @@ class StringGenerator
 		$chars      = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789./';
 		$charLength = strlen($chars) - 1;
 
+		$rounds = 0;
 		do {
 			$string     = '';
 
 			for ($i = 0; $i < $length; $i++) {
 				$string .= $chars[mt_rand(0, $charLength)];
 			}
-		} while (!preg_match($this->_pattern, $string));
+			++$rounds;
+		} while (!preg_match($this->_pattern, $string) && $rounds < $length);
 
 
 		return $string;

--- a/src/Security/StringGenerator.php
+++ b/src/Security/StringGenerator.php
@@ -47,6 +47,9 @@ class StringGenerator
 	public function generate($length = self::DEFAULT_LENGTH)
 	{
 		$self  = $this;
+		if ($length < 1) {
+			throw new \UnexpectedValueException('generate() expects an integer greater than or equal to 1');
+		}
 		$calls = array(
 			function() use ($self, $length) {
 				return $self->generateFromUnixRandom($length, '/dev/urandom');
@@ -104,7 +107,11 @@ class StringGenerator
 		if (!file_exists($path) || !is_readable($path)) {
 			throw new \RuntimeException(sprintf('Unable to read `%s`.', $path));
 		}
+		if ($length < 1) {
+			throw new \UnexpectedValueException('generate() expects an integer greater than or equal to 1');
+		}
 
+		$rounds = 0;
 		do {
 			$handle = fopen($path, 'rb');
 			stream_set_read_buffer($handle, 0);
@@ -117,8 +124,9 @@ class StringGenerator
 
 			$string = substr(base64_encode($random), 0, $length);
 			$string = str_replace('+', '.', rtrim($string, '='));
-			 
-		} while (!preg_match($this->_pattern, $string));
+			
+			++$rounds;
+		} while (!preg_match($this->_pattern, $string) && $rounds < $length);
 
 		return $string;
 	}

--- a/src/Security/StringGenerator.php
+++ b/src/Security/StringGenerator.php
@@ -15,7 +15,7 @@ namespace Message\Cog\Security;
 class StringGenerator
 {
 	const DEFAULT_LENGTH = 32;
-	protected $_pattern = '/.{32}/';
+	protected $_pattern = '/.*';
 
 
 	/**

--- a/src/Security/StringGenerator.php
+++ b/src/Security/StringGenerator.php
@@ -15,7 +15,7 @@ namespace Message\Cog\Security;
 class StringGenerator
 {
 	const DEFAULT_LENGTH = 32;
-	protected $_pattern = '/.*';
+	protected $_pattern = '/.*/';
 
 
 	/**

--- a/src/Security/StringGenerator.php
+++ b/src/Security/StringGenerator.php
@@ -147,6 +147,9 @@ class StringGenerator
 		if (!function_exists('openssl_random_pseudo_bytes')) {
 			throw new \RuntimeException('Function `openssl_random_pseudo_bytes` does not exist.');
 		}
+		if ($length < 1) {
+			throw new \UnexpectedValueException('generate() expects an integer greater than or equal to 1');
+		}
 
 		$rounds = 0;
 		do {
@@ -172,6 +175,9 @@ class StringGenerator
 	 */
 	public function generateNatively($length = self::DEFAULT_LENGTH)
 	{
+		if ($length < 1) {
+			throw new \UnexpectedValueException('generate() expects an integer greater than or equal to 1');
+		}
 		$chars      = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789./';
 		$charLength = strlen($chars) - 1;
 

--- a/src/Security/StringGenerator.php
+++ b/src/Security/StringGenerator.php
@@ -15,7 +15,7 @@ namespace Message\Cog\Security;
 class StringGenerator
 {
 	const DEFAULT_LENGTH = 32;
-	protected $_pattern = '/.*/';
+	protected $_pattern = '/.{32}/';
 
 
 	/**
@@ -106,7 +106,8 @@ class StringGenerator
 		}
 
 		do {
-			$handle = fopen($path, 'r');
+			$handle = fopen($path, 'rb');
+			stream_set_read_buffer($handle, 0);
 			$random = fread($handle, $length);
 			fclose($handle);
 
@@ -115,7 +116,8 @@ class StringGenerator
 			}
 
 			$string = substr(base64_encode($random), 0, $length);
-			$string = str_replace(array('+', '='), '.', $string);
+			$string = str_replace('+', '.', rtrim($string, '='));
+			 
 		} while (!preg_match($this->_pattern, $string));
 
 		return $string;
@@ -142,7 +144,7 @@ class StringGenerator
 			$random = openssl_random_pseudo_bytes($length);
 
 			$string = substr(base64_encode($random), 0, $length);
-			$string = str_replace(array('+', '='), '.', $string);
+			$string = str_replace('+', '.', rtrim($string, '='));
 		} while (!preg_match($this->_pattern, $string));
 		
 


### PR DESCRIPTION
* Use a pattern that actually validates the string length.
* Set `fread()` buffering to 0 so `8192 - $length` bytes of entropy are not wasted.