### PR TITLE
Change inaccurate default db.yml config

### DIFF
--- a/resources/fixtures/config/db.yml
+++ b/resources/fixtures/config/db.yml
@@ -1,5 +1,5 @@
 hostname: 127.0.0.1
 user: user
 pass: password
-name: table_name
+name: schema_name
 charset: utf8


### PR DESCRIPTION
This PR fixes the inaccurately named config for the database setup, as raised in https://github.com/mothership-ec/mothership-install/issues/5