### PR TITLE
Strip slash from slug objects when generating a URL

### DIFF
--- a/src/Routing/UrlGenerator.php
+++ b/src/Routing/UrlGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Message\Cog\Routing;
 
+use Message\Cog\ValueObject\Slug;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 /**
@@ -26,6 +27,13 @@ class UrlGenerator extends \Symfony\Component\Routing\Generator\UrlGenerator
 				);
 			}
 		}
+
+		array_walk($parameters, function (&$item) {
+			if ($item instanceof Slug) {
+				$item = (string) $item;
+				$item = ltrim($item, '/');
+			}
+		});
 
 		return parent::generate($name, $parameters, $referenceType);
 	}

--- a/src/Templating/Twig/Extension/Routing.php
+++ b/src/Templating/Twig/Extension/Routing.php
@@ -35,7 +35,7 @@ class Routing extends \Twig_Extension
 
     public function getPath($name, $parameters = array(), $absolute = false)
     {
-        return $this->_generator->generate($name, $parameters, $relative ? UrlGeneratorInterface::RELATIVE_PATH : UrlGeneratorInterface::ABSOLUTE_PATH);
+        return $this->_generator->generate($name, $parameters, !$absolute ? UrlGeneratorInterface::RELATIVE_PATH : UrlGeneratorInterface::ABSOLUTE_PATH);
     }
 
     public function getUrl($name, $parameters = array(), $schemeRelative = false)


### PR DESCRIPTION
#### What does this do?

Fixes the issue where URLs were being generated with a double slash. This was because the the `__toString()` method on the slug object prepends a '/' on the slug, which makes sense for relative urls, but not for absolute urls. This trims the slash off in the UrlGenerator class.

Also it replaces an undefined variable from Routing twig extension

#### How should this be manually tested?

#### Related PRs / Issues / Resources?

#### Anything else to add? (Screenshots, background context, etc)