### PR TITLE
Increase memory limit for asset:generate task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@
 ## 4.0.0
 
 + Initial open source version
+

--- a/src/Console/Command/AssetGenerator.php
+++ b/src/Console/Command/AssetGenerator.php
@@ -36,6 +36,30 @@ class AssetGenerator extends Command
 
 	protected function execute(InputInterface $input, OutputInterface $output)
 	{
+		$memory = ini_get('memory_limit');
+
+		switch (substr($memory, -1)) {
+			case 'M':
+			case 'm':
+				$memory = (int) $memory * 1048576;
+				break;
+			case 'K':
+			case 'k':
+				$memory = (int) $memory * 1024;
+				break;
+			case 'G':
+			case 'g':
+				$memory = (int) $memory * 1073741824;
+				break;
+			default:
+				break;
+		}
+
+		if ($memory < 536870912) {
+			$output->writeln('<info>Increasing memory limit to 512M</info>');
+			$iniSet = ini_set('memory_limit', 536870912);
+		}
+
 		// Call the twig environment. This seems bizarre but is important,
 		// otherwise the AssetManager won't know how to load Twig files. It is
 		// the only way we could get around a crazy dependency loop for the time being.
@@ -99,5 +123,10 @@ class AssetGenerator extends Command
 		$this->_services['asset.writer']->writeManagerAssets($this->_services['asset.manager']);
 
 		$output->writeln("<info>Compiled assets for all views</info>");
+
+		if (!empty($iniSet)) {
+			$output->writeln('<info>Resetting memory limit to ' . $iniSet . '</info>');
+			ini_set('memory_limit', $iniSet);
+		}
 	}
 }

--- a/src/Console/Command/AssetGenerator.php
+++ b/src/Console/Command/AssetGenerator.php
@@ -52,6 +52,7 @@ class AssetGenerator extends Command
 				$memory = (int) $memory * 1073741824;
 				break;
 			default:
+				$memory = (int) $memory;
 				break;
 		}
 


### PR DESCRIPTION
#### What does this do?
Increases memory limit on `asset:generate` task. It would be nice if this task was better optimised, but given the amount of heavy lifting it does I can't see it being fixed any time soon, and this is kind of a gotcha when using the installer for the first time. 

#### How should this be manually tested?
Reduce your memory limit to something pretty low and see if the task still works

#### Related PRs / Issues / Resources?

#### Anything else to add? (Screenshots, background context, etc)