### PR TITLE
Set garbage collection for sessions to one week by default

### DIFF
--- a/src/Application/Loader.php
+++ b/src/Application/Loader.php
@@ -81,8 +81,6 @@ namespace Message\Cog\Application {
 	 */
 	abstract class Loader
 	{
-		protected $_sessionSavePath = 'cog://tmp/sessions';
-
 		protected $_autoloader;
 		protected $_baseDir;
 		protected $_context;

--- a/src/Application/Loader.php
+++ b/src/Application/Loader.php
@@ -357,6 +357,10 @@ namespace Message\Cog\Application {
 			// otherwise date_default_timezone_get() gives strict warning if 
 			// timezone not set
 			@date_default_timezone_set(date_default_timezone_get());
+
+			// Session date will not be marked as garbage for collection until
+			// one week has passed
+			ini_set('session.gc_maxlifetime', 604800);
 		}
 
 		/**


### PR DESCRIPTION
This PR seeks to resolve the issue where users are being logged out unexpectedly despite the session expiry time being set to 0 (aka when the browser closes). Looks like `gc_maxlifetime` is set to 1440 seconds, or 24 minutes, by default, and after that it is tagged as garbage to be cleaned up. In this PR the value is set to a week.

This setting is set in the `_setDefaults()` protected method on the loader, and so can be overridden at an application level.

I'm not currently sure if this will work, but I have <a href="http://www.reddit.com/r/PHPhelp/comments/35achp/question_about_the_sessiongc_maxlifetime_ini/">asked Reddit</a> about whether setting this using ini_set is actually effective.
