### PR TITLE
Improved error messages and optimised sorting on collections

### DIFF
--- a/src/ValueObject/Collection.php
+++ b/src/ValueObject/Collection.php
@@ -25,6 +25,8 @@ class Collection implements \IteratorAggregate, \Countable, \ArrayAccess, \Seria
 
 	private $_items = [];
 
+	private $_sorted = false;
+
 	/**
 	 * Constructor.
 	 *
@@ -136,7 +138,8 @@ class Collection implements \IteratorAggregate, \Countable, \ArrayAccess, \Seria
 			}
 		}
 
-		$this->_key = $key;
+		$this->_key    = $key;
+		$this->_sorted = false;
 
 		return $this;
 	}
@@ -187,7 +190,7 @@ class Collection implements \IteratorAggregate, \Countable, \ArrayAccess, \Seria
 		$this->_sort   = $sorter;
 		$this->_sortBy = $by;
 
-		$this->_sort();
+		$this->_sorted = false;
 
 		return $this;
 	}
@@ -253,7 +256,7 @@ class Collection implements \IteratorAggregate, \Countable, \ArrayAccess, \Seria
 			$this->_items[] = $item;
 		}
 
-		$this->_sort();
+		$this->_sorted = false;
 
 		return $this;
 	}
@@ -364,6 +367,10 @@ class Collection implements \IteratorAggregate, \Countable, \ArrayAccess, \Seria
 	 */
 	public function all()
 	{
+		if (false === $this->_sorted) {
+			$this->_sort();
+		}
+
 		return $this->_items;
 	}
 
@@ -432,6 +439,8 @@ class Collection implements \IteratorAggregate, \Countable, \ArrayAccess, \Seria
 		else {
 			uasort($this->_items, $this->_sort);
 		}
+
+		$this->_sorted = true;
 	}
 
 	/**

--- a/src/ValueObject/Collection.php
+++ b/src/ValueObject/Collection.php
@@ -130,9 +130,9 @@ class Collection implements \IteratorAggregate, \Countable, \ArrayAccess, \Seria
 
 		if ($this->count() > 0) {
 			if (is_callable($key)) {
-				throw new \LogicException(sprintf('Cannot set key "%s" on a non-empty collection in %s', $this->_key, get_class($this)));
+				throw new \LogicException(sprintf('Cannot set key "%s" on a non-empty collection in %s', $key, get_class($this)));
 			} elseif (is_scalar($key)) {
-				throw new \LogicException(sprintf('Cannot set key (closure) on a non-empty collection in %s', $this->_key, get_class($this)));
+				throw new \LogicException(sprintf('Cannot set key (closure) on a non-empty collection in %s', get_class($this)));
 			}
 		}
 

--- a/src/ValueObject/Collection.php
+++ b/src/ValueObject/Collection.php
@@ -145,16 +145,21 @@ class Collection implements \IteratorAggregate, \Countable, \ArrayAccess, \Seria
 	 * Set the collection type. This must be a fully-qualified class name if the
 	 * collection values will be instances of this class.
 	 *
-	 * @param  string $type     Fully-qualified class name
+	 * @param  string $type                 Fully-qualified class name
 	 *
-	 * @return Collection       Returns $this for chainability
+	 * @return Collection                   Returns $this for chainability
 	 *
-	 * @throws \LogicException If collection is not empty
+	 * @throws \LogicException            If collection is not empty
+	 * @throws \InvalidArgumentException  Throws exception if $type is not a string
 	 */
 	public function setType($type)
 	{
+		if (!is_string($type)) {
+			throw new \InvalidArgumentException('Type must be a string, ' . gettype($type) . ' given in ' . get_class($this));
+		}
+
 		if ($this->count() > 0) {
-			throw new \LogicException(sprintf('Cannot set type "%s" on a non-empty collection in %s', $this->_type, get_class($this)));
+			throw new \LogicException(sprintf('Cannot set type "%s" on a non-empty collection in %s', $type, get_class($this)));
 		}
 
 		$this->_type = $type;

--- a/src/ValueObject/Collection.php
+++ b/src/ValueObject/Collection.php
@@ -129,9 +129,9 @@ class Collection implements \IteratorAggregate, \Countable, \ArrayAccess, \Seria
 		}
 
 		if ($this->count() > 0) {
-			if (is_callable($key)) {
+			if (is_scalar($key)) {
 				throw new \LogicException(sprintf('Cannot set key "%s" on a non-empty collection in %s', $key, get_class($this)));
-			} elseif (is_scalar($key)) {
+			} else {
 				throw new \LogicException(sprintf('Cannot set key (closure) on a non-empty collection in %s', get_class($this)));
 			}
 		}
@@ -265,7 +265,7 @@ class Collection implements \IteratorAggregate, \Countable, \ArrayAccess, \Seria
 	public function remove($key)
 	{
 		if (!$this->exists($key)) {
-			throw new \InvalidArgumentException(sprintf('Identifier "%s" does not exist on collection in %s', $this->_key, get_class($this)));
+			throw new \InvalidArgumentException(sprintf('Identifier "%s" does not exist on collection in %s', $key, get_class($this)));
 		}
 
 		unset($this->_items[$key]);


### PR DESCRIPTION
This PR adds better error messaging to the base Collection. When collections error, there is no way of knowing which collection is actually throwing the error if it is caught and displayed elsewhere in the code. This adds `get_class($this)` to all of the error messages to make it easier to debug. It also resolves the issue where throwing an exception in `setKey()` would break when setting the key as a callable