### PR TITLE
Update Symfony Console component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 		"ext-mysqli"   : "*",
 		"ext-intl"     : "*",
 
-		"symfony/console"                  : "2.3.*",
+		"symfony/console"                  : "2.7.*",
 		"symfony/event-dispatcher"         : "2.1.*",
 		"symfony/form"                     : "2.3.*",
 		"symfony/validator"                : "2.3.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "fe3d617b300015d0784cbac7f4e1de35",
+    "hash": "2c8e2e2e86df045161c3df625d26aad8",
     "packages": [
         {
             "name": "dflydev/markdown",
@@ -790,37 +790,40 @@
         },
         {
             "name": "symfony/console",
-            "version": "v2.3.30",
-            "target-dir": "Symfony/Component/Console",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Console.git",
-                "reference": "4ce3d2a448af346068e799a2182c3010ff2ed651"
+                "reference": "7f0bec04961c61c961df0cb8c2ae88dbfd83f399"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/4ce3d2a448af346068e799a2182c3010ff2ed651",
-                "reference": "4ce3d2a448af346068e799a2182c3010ff2ed651",
+                "url": "https://api.github.com/repos/symfony/Console/zipball/7f0bec04961c61c961df0cb8c2ae88dbfd83f399",
+                "reference": "7f0bec04961c61c961df0cb8c2ae88dbfd83f399",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.3.9"
             },
             "require-dev": {
+                "psr/log": "~1.0",
                 "symfony/event-dispatcher": "~2.1",
-                "symfony/phpunit-bridge": "~2.7"
+                "symfony/phpunit-bridge": "~2.7",
+                "symfony/process": "~2.1"
             },
             "suggest": {
-                "symfony/event-dispatcher": ""
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/process": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3-dev"
+                    "dev-master": "2.7-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\Console\\": ""
                 }
             },
@@ -840,7 +843,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2015-05-24 18:51:45"
+            "time": "2015-05-29 16:22:24"
         },
         {
             "name": "symfony/debug",
@@ -1968,16 +1971,16 @@
         },
         {
             "name": "zendframework/zend-debug",
-            "version": "2.4.2",
+            "version": "2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-debug.git",
-                "reference": "21bc83e39ccf8fb9b29282b3cb011d12f9df99c6"
+                "reference": "b6f9df59155391ca683c479a0d758f66ef73b3b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-debug/zipball/21bc83e39ccf8fb9b29282b3cb011d12f9df99c6",
-                "reference": "21bc83e39ccf8fb9b29282b3cb011d12f9df99c6",
+                "url": "https://api.github.com/repos/zendframework/zend-debug/zipball/b6f9df59155391ca683c479a0d758f66ef73b3b3",
+                "reference": "b6f9df59155391ca683c479a0d758f66ef73b3b3",
                 "shasum": ""
             },
             "require": {
@@ -1986,7 +1989,6 @@
             "require-dev": {
                 "fabpot/php-cs-fixer": "1.7.*",
                 "phpunit/phpunit": "~4.0",
-                "satooshi/php-coveralls": "dev-master",
                 "zendframework/zend-escaper": "2.*"
             },
             "suggest": {
@@ -1996,8 +1998,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.4-dev",
-                    "dev-develop": "2.5-dev"
+                    "dev-master": "2.5-dev",
+                    "dev-develop": "2.6-dev"
                 }
             },
             "autoload": {
@@ -2014,20 +2016,20 @@
                 "debug",
                 "zf2"
             ],
-            "time": "2015-05-07 14:55:31"
+            "time": "2015-06-03 14:05:35"
         },
         {
             "name": "zendframework/zend-escaper",
-            "version": "2.4.2",
+            "version": "2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-escaper.git",
-                "reference": "13f468ff824f3c83018b90aff892a1b3201383a9"
+                "reference": "a4b227d8a477f4e7e9073f8e0a7ae7dbd3104a73"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-escaper/zipball/13f468ff824f3c83018b90aff892a1b3201383a9",
-                "reference": "13f468ff824f3c83018b90aff892a1b3201383a9",
+                "url": "https://api.github.com/repos/zendframework/zend-escaper/zipball/a4b227d8a477f4e7e9073f8e0a7ae7dbd3104a73",
+                "reference": "a4b227d8a477f4e7e9073f8e0a7ae7dbd3104a73",
                 "shasum": ""
             },
             "require": {
@@ -2035,14 +2037,13 @@
             },
             "require-dev": {
                 "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "~4.0",
-                "satooshi/php-coveralls": "dev-master"
+                "phpunit/phpunit": "~4.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.4-dev",
-                    "dev-develop": "2.5-dev"
+                    "dev-master": "2.5-dev",
+                    "dev-develop": "2.6-dev"
                 }
             },
             "autoload": {
@@ -2059,7 +2060,7 @@
                 "escaper",
                 "zf2"
             ],
-            "time": "2015-05-07 14:55:31"
+            "time": "2015-06-03 14:05:37"
         }
     ],
     "packages-dev": [

--- a/src/Application/Context/Console.php
+++ b/src/Application/Context/Console.php
@@ -38,7 +38,6 @@ class Console implements ContextInterface
 		$this->_services['console.commands'] = function() {
 			return new CommandCollection(array(
 				new Command\EventList,
-				new Command\ModuleGenerate,
 				new Command\ModuleList,
 				new Command\RouteList,
 				new Command\RouteCollectionTree,

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -10,6 +10,7 @@ use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+use Symfony\Component\Console\Helper;
 
 
 /**

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -36,6 +36,12 @@ class Command extends BaseCommand implements ContainerAwareInterface
 		return $this->_services[$name];
 	}
 
+	/**
+	 * Create a Table output instance
+	 *
+	 * @param OutputInterface $output
+	 * @return Table
+	 */
 	protected function _getTable(OutputInterface $output)
 	{
 		return new Table($output);

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -6,6 +6,8 @@ use Message\Cog\Service\ContainerAwareInterface;
 use Message\Cog\Service\ContainerInterface;
 
 use Symfony\Component\Console\Command\Command as BaseCommand;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\Table;
 
 /**
  * Our wrapper around Symfony's Console component.
@@ -32,5 +34,10 @@ class Command extends BaseCommand implements ContainerAwareInterface
 	public function get($name)
 	{
 		return $this->_services[$name];
+	}
+
+	protected function _getTable(OutputInterface $output)
+	{
+		return new Table($output);
 	}
 }

--- a/src/Console/Command/EventList.php
+++ b/src/Console/Command/EventList.php
@@ -89,7 +89,7 @@ class EventList extends Command
 		});
 
 		$output->writeln('<info>Found ' . count($events) . ' registered event listeners.</info>');
-		$table = $this->getHelperSet()->get('table')
+		$table = $this->_getTable($output)
 			->setHeaders(array('Class', 'Method', 'Event', 'Priority'));
 
 		foreach($events as $event) {

--- a/src/Console/Command/ModuleList.php
+++ b/src/Console/Command/ModuleList.php
@@ -29,7 +29,7 @@ class ModuleList extends Command
 
 		$output->writeln('<info>Found ' . count($modules) . ' registered modules.</info>');
 
-		$table = $this->getHelperSet()->get('table')
+		$table = $this->_getTable($output)
 			->setHeaders(array('Name'));
 
 		foreach($modules as $module) {

--- a/src/Console/Command/ModuleNamespace.php
+++ b/src/Console/Command/ModuleNamespace.php
@@ -26,7 +26,7 @@ class ModuleNamespace extends Command
 		$modules = $this->get('module.loader')->getModules();
 		$locator = $this->get('module.locator');
 
-		$table = $table = $this->getHelperSet()->get('table')
+		$table = $this->_getTable($output)
 			->setHeaders(array('Name', 'Location'));
 
 		foreach($modules as $module) {

--- a/src/Console/Command/RouteList.php
+++ b/src/Console/Command/RouteList.php
@@ -6,6 +6,7 @@ use Message\Cog\Console\Command;
 
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\Table;
 
 /**
  * RouteList
@@ -25,23 +26,25 @@ class RouteList extends Command
 
 	protected function execute(InputInterface $input, OutputInterface $output)
 	{
+		ini_set('memory_limit', '2G');
 		$routes = $this->get('routes.compiled');
 
 		$output->writeln('<info>Found ' . count($routes) . ' registered routes.</info>');
 
-		$table = $this->getHelperSet()->get('table')
-			->setHeaders(array('Name', 'Path', 'Method', 'Format', 'Controller'));
+		$table = $this->_getTable($output)->setHeaders(array('Name', 'Path', 'Method', 'Format', 'Controller'));
 
 		foreach($routes as $name => $route) {
-
 			$defaults = $route->getDefaults();
-			$table->addRow(array(
+
+			$row = array(
 				$name,
 				$route->getPath(),
 				$route->getMethods() ? implode('|', $route->getMethods()) : 'ANY',
 				$defaults['_format'] ? $defaults['_format'] : 'ANY',
-				$defaults['_controller']
-			));
+				is_scalar($defaults['_controller']) ? $defaults['_controller'] : gettype($defaults['_controller']),
+			);
+
+			$table->addRow($row);
 		}
 
 		$table->render($output);

--- a/src/Console/Command/RouteList.php
+++ b/src/Console/Command/RouteList.php
@@ -6,7 +6,6 @@ use Message\Cog\Console\Command;
 
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Helper\Table;
 
 /**
  * RouteList

--- a/src/Console/Command/RouteList.php
+++ b/src/Console/Command/RouteList.php
@@ -26,7 +26,6 @@ class RouteList extends Command
 
 	protected function execute(InputInterface $input, OutputInterface $output)
 	{
-		ini_set('memory_limit', '2G');
 		$routes = $this->get('routes.compiled');
 
 		$output->writeln('<info>Found ' . count($routes) . ' registered routes.</info>');

--- a/src/Console/Command/ServiceList.php
+++ b/src/Console/Command/ServiceList.php
@@ -60,7 +60,7 @@ class ServiceList extends Command
 		$msg = 'Found %s registered services'.(strlen($term) ? ' matching `%s`' : '').'.';
 		$output->writeln(sprintf('<info>'.$msg.'</info>', count($result), $term));
 
-		$table = $this->getHelperSet()->get('table')
+		$table = $this->_getTable($output)
 			->setHeaders(array('Name', 'Type'));
 
 		foreach($result as $name => $service) {

--- a/src/Console/Command/TaskList.php
+++ b/src/Console/Command/TaskList.php
@@ -7,8 +7,6 @@ use Message\Cog\Console\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Helper\Table;
-
 
 /**
  * TaskList

--- a/src/Console/Command/TaskList.php
+++ b/src/Console/Command/TaskList.php
@@ -7,6 +7,8 @@ use Message\Cog\Console\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\Table;
+
 
 /**
  * TaskList
@@ -40,8 +42,7 @@ class TaskList extends Command
 
 		$output->writeln('<info>Found ' . count($tasks) . ' registered tasks.</info>');
 
-		$table = $this->getHelperSet()->get('table')
-			->setHeaders(array('Name', 'Description', 'Scheduled', 'Next run date'));
+		$table = $this->_getTable($output)->setHeaders(array('Name', 'Description', 'Scheduled', 'Next run date'));
 
 		ksort($tasks);
 		foreach($tasks as $task) {


### PR DESCRIPTION
This PR updates the Console component to 2.7, to allow for <a href="https://github.com/mothership-ec/up">Up!</a> to be integrated into Mothership, as it was causing a dependency conflict