### PR TITLE
Make default whitelist/fallback emails configurable

### DIFF
--- a/resources/fixtures/config/app.yml
+++ b/resources/fixtures/config/app.yml
@@ -1,6 +1,6 @@
 name: My Application
 base-url: default.com
-default-contact-email: dev@message.co.uk
+default-contact-email: contact@default.com
 default-email-from:
   email: noreply@default.com
   name: My Application

--- a/resources/fixtures/config/email.yml
+++ b/resources/fixtures/config/email.yml
@@ -1,0 +1,8 @@
+# The email address that emails will be sent to when in a non-live environment
+fallback-email: joebloggs@example.com
+
+# Array of email addresses, email address segments, or regular expressions to add to an email whitelist.
+# If an email is sent to an address that matches anything in the white list, it will be sent to this email address
+# instead of the fallback email. Note that regular expressions must use forward slashes for delimiters
+# e.g. ['joebloggs@example.com', '@test.com', '/.+@example\.com/']
+whitelist: []

--- a/src/Application/Bootstrap/Services.php
+++ b/src/Application/Bootstrap/Services.php
@@ -850,12 +850,11 @@ class Services implements ServicesInterface
 			$swift = new \Swift_Mailer($c['mail.transport']);
 			$dispatcher = new Cog\Mail\Mailer($swift);
 
-			$dispatcher->setWhitelistFallback('dev@message.co.uk');
-			$dispatcher->addToWhitelist('/.+@message\.co\.uk/');
-			$dispatcher->addToWhitelist('/.+@message\.uk\.com/');
+			$dispatcher->setWhitelistFallback($c['cfg']->email->fallbackEmail);
+			$dispatcher->addToWhitelist($c['cfg']->email->whitelist);
 
 			// Only enable whitelist filtering on non-live environments
-			if ($c['env']!== 'live') {
+			if ($c['env'] !== 'live') {
 				$dispatcher->enableToFiltering();
 			}
 

--- a/src/Mail/Mailer.php
+++ b/src/Mail/Mailer.php
@@ -141,7 +141,7 @@ class Mailer
 	 */
 	protected function _whitelistFilter(array $addresses)
 	{
-		$filtered = array();
+		$filtered = [];
 
 		// Filter each address
 		foreach ($addresses as $address => $name) {
@@ -169,6 +169,7 @@ class Mailer
 	 * Convert whitelist array into a list of regular expressions
 	 *
 	 * @param array $whitelist   Whitelist to convert to regular expressions
+	 * @throws \LogicException   Throws exception if item in array is not a string
 	 *
 	 * @return array
 	 */

--- a/src/Mail/Mailer.php
+++ b/src/Mail/Mailer.php
@@ -188,7 +188,7 @@ class Mailer
 					$item = str_replace($char, '\\' . $char, $item);
 				}
 
-				// Case to string for faux-strict typing.
+				// Cast to string for faux-strict typing.
 				switch ((string) strpos($item, '@')) {
 					// If @ is not present, add a wildcard to each end of the string
 					case '':

--- a/src/Mail/readme.md
+++ b/src/Mail/readme.md
@@ -12,8 +12,8 @@ See Swiftmailer docs here:
     $message = $this->get('mail.message');
 
     // You can use anything within SwiftMailer here.
-    $message->setTo('joe@message.co.uk', 'Joe Holdcroft');
-    $message->setFrom('test@message.co.uk');
+    $message->setTo('joe@example.com', 'Joe Bloggs');
+    $message->setFrom('test@example.com');
 
     // Set View has been added to Cog so that we can parse Views for the content.
     $message->setView('UniformWares:CMS::modules/mail', $params = array());
@@ -49,7 +49,7 @@ See Swiftmailer docs here:
     // SMTP
 
         $serviceContainer['mail.transport'] = function($c) {
-            $transport = new \Message\Cog\Mail\Transport\SMTP('mail.message.co.uk', 25);
+            $transport = new \Message\Cog\Mail\Transport\SMTP('mail.example.com', 25);
 
             $transport->setUsername('test');
             $transport->setPassword('testpw');


### PR DESCRIPTION
Resolves https://github.com/mothership-ec/cog/issues/423

This removes references to @message.co.uk email addresses in the main codebase (they are still present in test files). It also adds an `email.yml` file, where you can set the fallback email address, as well as a list of email addresses, partial email addresses, and regular expressions, to add to the email whitelist