### PR TITLE
Don't sort if no sort set

### DIFF
--- a/src/ValueObject/Collection.php
+++ b/src/ValueObject/Collection.php
@@ -433,6 +433,12 @@ class Collection implements \IteratorAggregate, \Countable, \ArrayAccess, \Seria
 	 */
 	private function _sort()
 	{
+		// No sort set, set sorted to true and return
+		if (!$this->_sort) {
+			$this->_sorted = true;
+			return;
+		}
+
 		if (self::SORT_KEY === $this->_sortBy) {
 			uksort($this->_items, $this->_sort);
 		}


### PR DESCRIPTION
Collections where all() is called before sort is set will break. For most cases this is fine as the constructor sets a default sort. However when the constructor is overridden (such as in the CookieTrail) this will break as all gets called in the setValidator() method.

Test by looking at a page with a cookie trail.