### PR TITLE
Array issues in queryBuilder

### DIFF
--- a/src/DB/QueryBuilder.php
+++ b/src/DB/QueryBuilder.php
@@ -194,7 +194,7 @@ class QueryBuilder implements QueryBuilderInterface
 	public function groupBy($groupBy)
 	{
 		if (is_array($groupBy)) {
-			array_merge($this->_groupBy[], $groupBy);
+			$this->_groupBy = array_merge($this->_groupBy, $groupBy);
 		} else {
 			$this->_groupBy[] = (string) $groupBy;
 		}
@@ -232,7 +232,7 @@ class QueryBuilder implements QueryBuilderInterface
 	public function orderBy($orderBy)
 	{
 		if (is_array($orderBy)) {
-			array_merge($this->_orderBy[], $orderBy);
+			$this->_orderBy = array_merge($this->_orderBy, $orderBy);
 		} else {
 			$this->_orderBy[] = (string) $orderBy;
 		}

--- a/tests/DB/QueryBuilderTest.php
+++ b/tests/DB/QueryBuilderTest.php
@@ -162,6 +162,21 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase
 		$this->assertEquals($expected, trim(preg_replace('/\s+/', ' ', $query)));
 	}
 
+	public function testGroupByArrayMulti()
+	{ 
+		$query = $this->_builder
+			->select("*")
+			->from('table')
+			->groupBy(['col', 'col2'])
+			->groupBy(['col3', 'col4'])
+			->getQueryString()
+		;
+
+		$expected = "SELECT * FROM table GROUP BY col, col2, col3, col4";
+
+		$this->assertEquals($expected, trim(preg_replace('/\s+/', ' ', $query)));
+	}
+
 	public function testOrderBy()
 	{
 		$query = $this->_builder
@@ -201,6 +216,21 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase
 		;
 
 		$expected = "SELECT * FROM table ORDER BY col, col2";
+
+		$this->assertEquals($expected, trim(preg_replace('/\s+/', ' ', $query)));
+	}
+
+	public function testOrderByArrayMulti()
+	{ 
+		$query = $this->_builder
+			->select("*")
+			->from('table')
+			->orderBy(['col', 'col2'])
+			->orderBy(['col3', 'col4'])
+			->getQueryString()
+		;
+
+		$expected = "SELECT * FROM table ORDER BY col, col2, col3, col4";
 
 		$this->assertEquals($expected, trim(preg_replace('/\s+/', ' ', $query)));
 	}

--- a/tests/DB/QueryBuilderTest.php
+++ b/tests/DB/QueryBuilderTest.php
@@ -148,6 +148,20 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase
 		$this->assertEquals($expected, trim(preg_replace('/\s+/', ' ', $query)));
 	}
 
+	public function testGroupByArray()
+	{ 
+		$query = $this->_builder
+			->select("*")
+			->from('table')
+			->groupBy(['col', 'col2'])
+			->getQueryString()
+		;
+
+		$expected = "SELECT * FROM table GROUP BY col, col2";
+
+		$this->assertEquals($expected, trim(preg_replace('/\s+/', ' ', $query)));
+	}
+
 	public function testOrderBy()
 	{
 		$query = $this->_builder
@@ -169,6 +183,20 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase
 			->from('table')
 			->orderBy('col')
 			->orderBy('col2')
+			->getQueryString()
+		;
+
+		$expected = "SELECT * FROM table ORDER BY col, col2";
+
+		$this->assertEquals($expected, trim(preg_replace('/\s+/', ' ', $query)));
+	}
+
+	public function testOrderByArray()
+	{ 
+		$query = $this->_builder
+			->select("*")
+			->from('table')
+			->orderBy(['col', 'col2'])
 			->getQueryString()
 		;
 


### PR DESCRIPTION
This was breaking on basic functionality when using arrays.

Run the tests to see if it works. Perhaps test in other areas, this cant be used anywhere as it will always give a runtime error.