### PR TITLE
Run migrations in timestamp order

### DIFF
--- a/src/Application/Bootstrap/Services.php
+++ b/src/Application/Bootstrap/Services.php
@@ -813,6 +813,11 @@ class Services implements ServicesInterface
 		};
 
 		// Shortcut to mysql migration adapter
+		$services['migrator'] = function($c) {
+			return $c['migration.mysql'];
+		};
+
+		// Preserved for backwards compatibility. Use more accurately named `migrator` instead.
 		$services['migration'] = function($c) {
 			return $c['migration.mysql'];
 		};

--- a/src/Console/Command/MigrateInstall.php
+++ b/src/Console/Command/MigrateInstall.php
@@ -29,7 +29,7 @@ class MigrateInstall extends Command
 
 		$this->get('migration.mysql.loader')->install();
 
-		foreach ($this->get('migration')->getNotes() as $note) {
+		foreach ($this->get('migrator')->getNotes() as $note) {
 			$output->writeln($note);
 		}
 	}

--- a/src/Console/Command/MigrateRefresh.php
+++ b/src/Console/Command/MigrateRefresh.php
@@ -27,9 +27,9 @@ class MigrateRefresh extends Command
 	{
 		$output->writeln('<info>Refreshing migrations...</info>');
 
-		$this->get('migration')->refresh();
+		$this->get('migrator')->refresh();
 
-		foreach ($this->get('migration')->getNotes() as $note) {
+		foreach ($this->get('migrator')->getNotes() as $note) {
 			$output->writeln($note);
 		}
 	}

--- a/src/Console/Command/MigrateReset.php
+++ b/src/Console/Command/MigrateReset.php
@@ -27,9 +27,9 @@ class MigrateReset extends Command
 	{
 		$output->writeln('<info>Resetting all migrations...</info>');
 
-		$this->get('migration')->reset();
+		$this->get('migrator')->reset();
 
-		foreach ($this->get('migration')->getNotes() as $note) {
+		foreach ($this->get('migrator')->getNotes() as $note) {
 			$output->writeln($note);
 		}
 	}

--- a/src/Console/Command/MigrateRollback.php
+++ b/src/Console/Command/MigrateRollback.php
@@ -27,9 +27,9 @@ class MigrateRollback extends Command
 	{
 		$output->writeln('<info>Rolling back last migration batch...</info>');
 
-		$this->get('migration')->rollback();
+		$this->get('migrator')->rollback();
 
-		foreach ($this->get('migration')->getNotes() as $note) {
+		foreach ($this->get('migrator')->getNotes() as $note) {
 			$output->writeln($note);
 		}
 	}

--- a/src/Console/Command/MigrateRun.php
+++ b/src/Console/Command/MigrateRun.php
@@ -36,11 +36,10 @@ class MigrateRun extends Command
 
 			// Get the reference
 			$references[] = '@' . str_replace('\\', ':', $module);
-
 		}
 
 		try {
-			$this->get('migration')->runFromReferences($references);
+			$this->get('migrator')->runFromReferences($references);
 		}
 		catch (\Message\Cog\DB\Exception $e) {
 			$output->writeln('<error>Migration error: Have you run `migrate:install`?</error>');
@@ -48,11 +47,11 @@ class MigrateRun extends Command
 		}
 
 		// Output this migration's notes
-		foreach ($this->get('migration')->getNotes() as $note) {
+		foreach ($this->get('migrator')->getNotes() as $note) {
 			$output->writeln($note);
 		}
 
 		// Clear the notes
-		$this->get('migration')->clearNotes();
+		$this->get('migrator')->clearNotes();
 	}
 }

--- a/src/Console/Command/MigrateRun.php
+++ b/src/Console/Command/MigrateRun.php
@@ -30,27 +30,29 @@ class MigrateRun extends Command
 
 		// Get the loaded modules
 		$modules = $this->get('module.loader')->getModules();
+		$references = [];
 
 		foreach ($modules as $module) {
 
 			// Get the reference
-			$reference = '@' . str_replace('\\', ':', $module);
+			$references[] = '@' . str_replace('\\', ':', $module);
 
-			try {
-				$this->get('migration')->run($reference);
-			}
-			catch (\Message\Cog\DB\Exception $e) {
-				$output->writeln('<error>Migration error: Have you run `migrate:install`?</error>');
-				return;
-			}
-
-			// Output this migration's notes
-			foreach ($this->get('migration')->getNotes() as $note) {
-				$output->writeln($note);
-			}
-
-			// Clear the notes
-			$this->get('migration')->clearNotes();
 		}
+
+		try {
+			$this->get('migration')->runFromReferences($references);
+		}
+		catch (\Message\Cog\DB\Exception $e) {
+			$output->writeln('<error>Migration error: Have you run `migrate:install`?</error>');
+			return;
+		}
+
+		// Output this migration's notes
+		foreach ($this->get('migration')->getNotes() as $note) {
+			$output->writeln($note);
+		}
+
+		// Clear the notes
+		$this->get('migration')->clearNotes();
 	}
 }

--- a/src/Migration/Adapter/MySQL/Loader.php
+++ b/src/Migration/Adapter/MySQL/Loader.php
@@ -179,7 +179,7 @@ class Loader implements LoaderInterface
 			$migration   = $this->resolve($file, $row->path);
 
 			if (false !== $migration) {
-				$migrations[] = $this->resolve($file, $row->path);
+				$migrations[$row->path] = $this->resolve($file, $row->path);
 			} else {
 				$this->_failures[] = $file->getRealPath();
 			}

--- a/src/Migration/Adapter/MySQL/Loader.php
+++ b/src/Migration/Adapter/MySQL/Loader.php
@@ -82,7 +82,7 @@ class Loader implements LoaderInterface
 		foreach ($files as $file) {
 			if ($file->isFile()) {
 				$fileReference = 'cog://' . $reference . 'resources/migrations/' . $file->getBasename();
-				$key = $this->_getTimestamp($fileReference);
+				$key = $this->_getKey($fileReference);
 				$migrations[$key] = $this->resolve($file, $fileReference);
 			}
 		}
@@ -179,7 +179,7 @@ class Loader implements LoaderInterface
 			$file = new File($row->path);
 			$migration   = $this->resolve($file, $row->path);
 
-			$key = (false !== $migration) ? $this->_getTimestamp($row->path) : $this->_getTimestamp($file->getRealPath());
+			$key = (false !== $migration) ? $this->_getKey($row->path) : $this->_getKey($file->getRealPath());
 
 			if (false !== $migration) {
 				$migrations[$key] = $this->resolve($file, $row->path);
@@ -191,7 +191,15 @@ class Loader implements LoaderInterface
 		return $migrations;
 	}
 
-	private function _getTimestamp($path)
+	/**
+	 * Use the timestamp in the filename to create a key, allowing the Migrator to order the migrations in chronological
+	 * order
+	 *
+	 * @param $path
+	 *
+	 * @return string
+	 */
+	private function _getKey($path)
 	{
 		if (!is_string($path)) {
 			throw new \InvalidArgumentException('Path must be a string, ' . gettype($path) . ' given');

--- a/src/Migration/Migrator.php
+++ b/src/Migration/Migrator.php
@@ -48,7 +48,7 @@ class Migrator {
 				$this->_note("<comment>No migrations to run for `". $reference . "`</comment>");
 			}
 
-			$migrations = array_merge($migrations, $migrationsForReference);
+			$migrations = $migrations + $migrationsForReference;
 		}
 
 		ksort($migrations);

--- a/src/Migration/Migrator.php
+++ b/src/Migration/Migrator.php
@@ -59,6 +59,7 @@ class Migrator {
 		foreach ($migrations as $key => $migration) {
 			foreach ($run as $r) {
 				if (get_class($migration) === get_class($r)) {
+					$this->_note("<comment>Migration `" . $migration->getReference() . "` already run</comment>");
 					unset($migrations[$key]);
 				}
 			}
@@ -184,7 +185,7 @@ class Migrator {
 	protected function _runCollection()
 	{
 		if (count($this->_collection) == 0) {
-			$this->_note("<comment>No migrations to run</comment>");
+			$this->_note("<comment>No migrations run</comment>");
 		}
 
 		$batch = $this->_getNextBatchNumber();

--- a/src/Migration/Migrator.php
+++ b/src/Migration/Migrator.php
@@ -35,9 +35,6 @@ class Migrator {
 	public function run($reference)
 	{
 		$this->runFromReferences([$reference]);
-		// Find the migrations in the path that have not yet been run
-//		$migrations = $inPath = $this->_loader->getFromReference($reference);
-
 	}
 
 	public function runFromReferences(array $references)

--- a/src/Migration/Migrator.php
+++ b/src/Migration/Migrator.php
@@ -34,8 +34,28 @@ class Migrator {
 	 */
 	public function run($reference)
 	{
+		$this->runFromReferences([$reference]);
 		// Find the migrations in the path that have not yet been run
-		$migrations = $inPath = $this->_loader->getFromReference($reference);
+//		$migrations = $inPath = $this->_loader->getFromReference($reference);
+
+	}
+
+	public function runFromReferences(array $references)
+	{
+		$migrations = [];
+
+		foreach ($references as $reference) {
+			$migrationsForReference = $this->_loader->getFromReference($reference);
+
+			if (count($migrationsForReference) === 0) {
+				$this->_note("<comment>No migrations to run for `". $reference . "`</comment>");
+			}
+
+			$migrations = array_merge($migrations, $migrationsForReference);
+		}
+
+		ksort($migrations);
+
 		$run = $this->_loader->getAll();
 
 		// Diff the migrations in the path and those run to get new migrations


### PR DESCRIPTION
This PR changes the way that the `migrate:run` command works so that instead of looping through the modules and running the migrations for that module, it loads all of the migrations and sorts them by filename (and therefore the unix timestamp) so that they run in chronological order. This prevents issues where a migration could rely on a table that hasn't yet been created.

In order to maintain BC, I have added a new method called `runFromReferences()` which takes an array of references. The original `run()` method gives the given reference parameter to `runFromReferences()` in an array