### PR TITLE
array_merge resets integer keys

### DIFF
--- a/src/Form/Extension/Type/LinkedChoice.php
+++ b/src/Form/Extension/Type/LinkedChoice.php
@@ -31,14 +31,10 @@ class LinkedChoice extends AbstractType
 	public function buildForm(FormBuilderInterface $builder, array $options)
 	{
 		foreach ($this->_groups as $name => $choices) {
-			// Cannot use array-merge as we need to preserve any integer keys.
-			$choiceData = ['none' => 'None'];
-			foreach ($choices as $key => $value) {
-				$choiceData[$key] = $value;
-			}
+			$choices = ['none' => 'None'] + $choices;
 
 			$builder->add($name, 'choice', array(
-				'choices'     => $choiceData,
+				'choices'     => $choices,
 				'empty_value' => 'Please select...',
 			));
 		}

--- a/src/Form/Extension/Type/LinkedChoice.php
+++ b/src/Form/Extension/Type/LinkedChoice.php
@@ -31,9 +31,14 @@ class LinkedChoice extends AbstractType
 	public function buildForm(FormBuilderInterface $builder, array $options)
 	{
 		foreach ($this->_groups as $name => $choices) {
-			$choices = array_merge(array('none' => 'None'), $choices);
+
+			$choiceData = ['none' => 'None'];
+			foreach ($choices as $key => $value) {
+				$choiceData[$key] = $value;
+			}
+
 			$builder->add($name, 'choice', array(
-				'choices'     => $choices,
+				'choices'     => $choiceData,
 				'empty_value' => 'Please select...',
 			));
 		}

--- a/src/Form/Extension/Type/LinkedChoice.php
+++ b/src/Form/Extension/Type/LinkedChoice.php
@@ -31,7 +31,7 @@ class LinkedChoice extends AbstractType
 	public function buildForm(FormBuilderInterface $builder, array $options)
 	{
 		foreach ($this->_groups as $name => $choices) {
-
+			// Cannot use array-merge as we need to preserve any integer keys.
 			$choiceData = ['none' => 'None'];
 			foreach ($choices as $key => $value) {
 				$choiceData[$key] = $value;


### PR DESCRIPTION
This came about due to a problem from within commerce. Try creating a product which has variants with values which look like integers. For example "Value":"20".

Then try assigning to a page using the `Productoption` Field. If you look at the generated select box, the values which look like numbers will have wrong values. Something like `<option value="4">20</option>` where the value *should* be 20.

This is due to array_merge resetting integer keys. This change means that integer keys are preserved.
