### PR TITLE
Maintain join order in query builder, plus unit tests

### DIFF
--- a/tests/DB/QueryBuilderTest.php
+++ b/tests/DB/QueryBuilderTest.php
@@ -478,6 +478,38 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase
 		$this->assertEquals($expected, trim(preg_replace('/\s+/', ' ', $query)));
 	}
 
+	public function testJoinBeforeLeftJoin()
+	{
+		$expected = "SELECT * FROM table_a JOIN table_b ON id = id LEFT JOIN table_c ON id = id";
+		$this->_parser->shouldReceive('parse')->once()->passthru();
+
+		$query = $this->_builder
+			->select("*")
+			->from('table_a')
+			->join('table_b', 'id = id')
+			->leftJoin('table_c', 'id = id')
+			->getQueryString()
+		;
+
+		$this->assertEquals($expected, trim(preg_replace('/\s+/', ' ', $query)));
+	}
+
+	public function testLeftJoinBeforeJoin()
+	{
+		$expected = "SELECT * FROM table_a LEFT JOIN table_b ON id = id JOIN table_c ON id = id";
+		$this->_parser->shouldReceive('parse')->once()->passthru();
+
+		$query = $this->_builder
+			->select("*")
+			->from('table_a')
+			->leftJoin('table_b', 'id = id')
+			->join('table_c', 'id = id')
+			->getQueryString()
+		;
+
+		$this->assertEquals($expected, trim(preg_replace('/\s+/', ' ', $query)));
+	}
+
 	public function testLeftJoinSimple()
 	{
 		$expected = "SELECT * FROM table_a LEFT JOIN table_b ON id = id";


### PR DESCRIPTION
This PR maintains the order in which joins are added to the query builder, as before the inner joins were being output before the left joins, which could lead to errors if an inner join relied on a left join.

This PR groups all joins in an array together and marks them with a type. A switch is then used when building the query string