### PR TITLE
Automatically translate flash messages

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -47,11 +47,14 @@ class Controller implements ContainerAwareInterface, RequestAwareInterface
 	/**
 	 * Add a flash message to the session.
 	 *
-	 * @param string $type    The type of message
-	 * @param string $message The message to add
+	 * @param string $type      The type of message
+	 * @param string $message   The message or translation key to add to the flash bag
+	 * @param array $params    Parameters to pass to translator
 	 */
-	public function addFlash($type, $message)
+	public function addFlash($type, $message, array $params = [])
 	{
+		$message = $this->trans($message, $params);
+
 		return $this->get('http.session')->getFlashBag()->add($type, $message);
 	}
 


### PR DESCRIPTION
This PR makes adding flash messages more convenient. Flash message should always be translation strings when in Mothership core, but you currently need to call `$this->trans()` on your message before passing it into the `addFlash()` method which is just a big stupid hassle. This PR puts that call in the `Controller::addFlash()` method, and adds an optional `$params` third parameter to the method for passing params to the translator