### PR TITLE
More db join options (specifically allowing USING clauses)

### DIFF
--- a/src/DB/QueryBuilder.php
+++ b/src/DB/QueryBuilder.php
@@ -120,6 +120,8 @@ class QueryBuilder implements QueryBuilderInterface
 			throw new \InvalidArgumentException('On statement must be a string');
 		}
 
+		$statement = $on ? $statement : '(' . $statement . ')';
+
 		if ($table) {
 			$this->_join[] = [
 				'table_reference' => $table,
@@ -188,6 +190,8 @@ class QueryBuilder implements QueryBuilderInterface
 		if (!is_string($statement)) {
 			throw new \InvalidArgumentException('On statement must be a string');
 		}
+
+		$statement = $on ? $statement : '(' . $statement . ')';
 
 		if ($table) {
 			$this->_join[] = [

--- a/src/DB/QueryBuilder.php
+++ b/src/DB/QueryBuilder.php
@@ -8,7 +8,7 @@ use Message\Cog\DB\QueryParser;
 use Message\Cog\DB\Query;
 
 /**
- * Builds a database query by concatinating query elements given.
+ * Builds a database query by concatenating query elements given.
  *
  * @author Eleanor Shakeshaft <eleanor@message.co.uk>
  */
@@ -100,36 +100,40 @@ class QueryBuilder implements QueryBuilderInterface
 	}
 
 	/**
-	 * Joins $table as $alias using $onStatement.
+	 * Joins $table as $alias using $statement.
 	 *
 	 * @param  string                           $alias       Name of the table or table alias
-	 * @param  string                           $onStatement Statement to join on
+	 * @param  string                           $statement   Statement to join on
 	 * @param  QueryBuilder | string            $table       Data / table
+	 * @param  bool                             $on          Set to true if the join uses the ON clause, and false if
+	 *                                                       it uses the USING clause
 	 *
 	 * @return QueryBuilder                     $this
 	 */
-	public function join($alias, $onStatement, $table = null)
+	public function join($alias, $statement, $table = null, $on = true)
 	{
 		if (!is_string($alias)) {
 			throw new \InvalidArgumentException('Alias must be a string');
 		}
 
-		if (!is_string($onStatement)) {
+		if (!is_string($statement)) {
 			throw new \InvalidArgumentException('On statement must be a string');
 		}
 
 		if ($table) {
 			$this->_join[] = [
 				'table_reference' => $table,
-				'on_statement'    => $onStatement,
+				'statement'       => $statement,
 				'alias'           => $alias,
 				'type'            => self::INNER_JOIN_TAG,
+				'clause'          => $on ? 'ON' : 'USING'
 			];
 		} else {
 			$this->_join[] = [
 				'table_reference' => $alias,
-				'on_statement'    => $onStatement,
+				'statement'       => $statement,
 				'type'            => self::INNER_JOIN_TAG,
+				'clause'          => $on ? 'ON' : 'USING'
 			];
 		}
 
@@ -137,47 +141,107 @@ class QueryBuilder implements QueryBuilderInterface
 	}
 
 	/**
+	 * Join using the ON clause
+	 *
+	 * @param  string                           $alias       Name of the table or table alias
+	 * @param  string                           $statement   Statement to join on
+	 * @param  QueryBuilder | string            $table       Data / table
+	 *
+	 * @return QueryBuilder
+	 */
+	public function joinOn($alias, $statement, $table = null)
+	{
+		return $this->join($alias, $statement, $table, true);
+	}
+
+	/**
+	 * Join using the USING clause
+	 *
+	 * @param  string                           $alias       Name of the table or table alias
+	 * @param  string                           $statement   Statement to join on
+	 * @param  QueryBuilder | string            $table       Data / table
+	 *
+	 * @return QueryBuilder
+	 */
+	public function joinUsing($alias, $statement, $table = null)
+	{
+		return $this->join($alias, $statement, $table, false);
+	}
+
+	/**
 	 * Joins $table as $alias using $onStatement.
 	 *
 	 * @param  string                           $alias       Name of the table or table alias
-	 * @param  string                           $onStatement Statement to join on
+	 * @param  string                           $statement   Statement to join on
 	 * @param  QueryBuilder | string            $table       Data / table
+	 * @param  bool                             $on          Set to true if the join uses the ON clause, and false if
+	 *                                                       it uses the USING clause
 	 *
 	 * @return QueryBuilder                     $this
 	 */
-	public function leftJoin($alias, $onStatement, $table = null)
+	public function leftJoin($alias, $statement, $table = null, $on = true)
 	{
 		if (!is_string($alias)) {
 			throw new \InvalidArgumentException('Alias must be a string');
 		}
 
-		if (!is_string($onStatement)) {
+		if (!is_string($statement)) {
 			throw new \InvalidArgumentException('On statement must be a string');
 		}
 
 		if ($table) {
 			$this->_join[] = [
 				'table_reference' => $table,
-				'on_statement'    => $onStatement,
+				'statement'       => $statement,
 				'alias'           => $alias,
-				'type'            => self::LEFT_JOIN_TAG
+				'type'            => self::LEFT_JOIN_TAG,
+				'clause'          => $on ? 'ON' : 'USING'
 			];
 		} else {
 			$this->_join[] = [
 				'table_reference' => $alias,
-				'on_statement'    => $onStatement,
+				'statement'       => $statement,
 				'type'            => self::LEFT_JOIN_TAG,
+				'clause'          => $on ? 'ON' : 'USING'
 			];
 		}
 
 		return $this;
+	}
+
+	/**
+	 * Left join using the ON clause
+	 *
+	 * @param  string                           $alias       Name of the table or table alias
+	 * @param  string                           $statement   Statement to join on
+	 * @param  QueryBuilder | string            $table       Data / table
+	 *
+	 * @return QueryBuilder
+	 */
+	public function leftJoinOn($alias, $statement, $table = null)
+	{
+		return $this->leftJoin($alias, $statement, $table, true);
+	}
+
+	/**
+	 * Left join using the USING clause
+	 *
+	 * @param  string                           $alias       Name of the table or table alias
+	 * @param  string                           $statement   Statement to join on
+	 * @param  QueryBuilder | string            $table       Data / table
+	 *
+	 * @return QueryBuilder
+	 */
+	public function leftJoinUsing($alias, $statement, $table = null)
+	{
+		return $this->leftJoin($alias, $statement, $table, false);
 	}
 
 	/**
 	 * Builds into the where statement using "AND" as default.
 	 *
-	 * @param  string | closure  $statement the statement to append
-	 * @param  array             $variable  variable to substitute in
+	 * @param  string | \Closure $statement the statement to append
+	 * @param  array             $variables variable to substitute in
 	 * @param  boolean           $and       append using and if true, or if false
 	 *
 	 * @return QueryBuilder                 $this
@@ -446,7 +510,7 @@ class QueryBuilder implements QueryBuilderInterface
 					$this->_query .= " " . $join['alias'];
 				}
 
-				$this->_query .= " ON " . $join['on_statement'];
+				$this->_query .= " ". $join['clause'] . " " . $join['statement'];
 			}
 		}
 

--- a/tests/DB/QueryBuilderTest.php
+++ b/tests/DB/QueryBuilderTest.php
@@ -102,8 +102,6 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase
 			->getQueryString()
 		;
 
-
-
 		$this->assertEquals($expected, trim(preg_replace('/\s+/', ' ', $query)));
 	}
 
@@ -478,6 +476,126 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase
 		$this->assertEquals($expected, trim(preg_replace('/\s+/', ' ', $query)));
 	}
 
+	public function testJoinSimpleWithOn()
+	{
+		$expected = "SELECT * FROM table_a JOIN table_b ON id = id";
+		$this->_parser->shouldReceive('parse')->once()->passthru();
+
+		$query = $this->_builder
+			->select("*")
+			->from('table_a')
+			->join('table_b', 'id = id', null, true)
+			->getQueryString()
+		;
+
+		$this->assertEquals($expected, trim(preg_replace('/\s+/', ' ', $query)));
+	}
+
+	public function testJoinAliasWithOn()
+	{
+		$expected = "SELECT * FROM table_a JOIN table_b alias ON id = id";
+		$this->_parser->shouldReceive('parse')->once()->passthru();
+
+		$query = $this->_builder
+			->select("*")
+			->from('table_a')
+			->join('alias', 'id = id', 'table_b', true)
+			->getQueryString()
+		;
+
+		$this->assertEquals($expected, trim(preg_replace('/\s+/', ' ', $query)));
+	}
+
+	public function testJoinSimpleWithUsing()
+	{
+		$expected = "SELECT * FROM table_a JOIN table_b USING (id)";
+		$this->_parser->shouldReceive('parse')->once()->passthru();
+
+		$query = $this->_builder
+			->select("*")
+			->from('table_a')
+			->join('table_b', 'id', null, false)
+			->getQueryString()
+		;
+
+		$this->assertEquals($expected, trim(preg_replace('/\s+/', ' ', $query)));
+	}
+
+	public function testJoinAliasWithUsing()
+	{
+		$expected = "SELECT * FROM table_a JOIN table_b alias USING (id)";
+		$this->_parser->shouldReceive('parse')->once()->passthru();
+
+		$query = $this->_builder
+			->select("*")
+			->from('table_a')
+			->join('alias', 'id', 'table_b', false)
+			->getQueryString()
+		;
+
+		$this->assertEquals($expected, trim(preg_replace('/\s+/', ' ', $query)));
+	}
+
+	public function testJoinOnSimple()
+	{
+		$expected = "SELECT * FROM table_a JOIN table_b ON id = id";
+		$this->_parser->shouldReceive('parse')->once()->passthru();
+
+		$query = $this->_builder
+			->select("*")
+			->from('table_a')
+			->joinOn('table_b', 'id = id')
+			->getQueryString()
+		;
+
+		$this->assertEquals($expected, trim(preg_replace('/\s+/', ' ', $query)));
+	}
+
+	public function testJoinOnAlias()
+	{
+		$expected = "SELECT * FROM table_a JOIN table_b alias ON id = id";
+		$this->_parser->shouldReceive('parse')->once()->passthru();
+
+		$query = $this->_builder
+			->select("*")
+			->from('table_a')
+			->joinOn('alias', 'id = id', 'table_b')
+			->getQueryString()
+		;
+
+		$this->assertEquals($expected, trim(preg_replace('/\s+/', ' ', $query)));
+	}
+
+	public function testJoinUsingSimple()
+	{
+		$expected = "SELECT * FROM table_a JOIN table_b USING (id)";
+		$this->_parser->shouldReceive('parse')->once()->passthru();
+
+		$query = $this->_builder
+			->select("*")
+			->from('table_a')
+			->joinUsing('table_b', 'id')
+			->getQueryString()
+		;
+
+		$this->assertEquals($expected, trim(preg_replace('/\s+/', ' ', $query)));
+	}
+
+	public function testJoinUsingAlias()
+	{
+		$expected = "SELECT * FROM table_a JOIN table_b alias USING (id)";
+		$this->_parser->shouldReceive('parse')->once()->passthru();
+
+		$query = $this->_builder
+			->select("*")
+			->from('table_a')
+			->joinUsing('alias', 'id', 'table_b')
+			->getQueryString()
+		;
+
+		$this->assertEquals($expected, trim(preg_replace('/\s+/', ' ', $query)));
+	}
+
 	public function testJoinBeforeLeftJoin()
 	{
 		$expected = "SELECT * FROM table_a JOIN table_b ON id = id LEFT JOIN table_c ON id = id";
@@ -535,6 +653,127 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase
 			->select("*")
 			->from('table_a')
 			->leftJoin('alias', 'id = id', 'table_b')
+			->getQueryString()
+		;
+
+		$this->assertEquals($expected, trim(preg_replace('/\s+/', ' ', $query)));
+	}
+
+
+	public function testLeftJoinSimpleWithOn()
+	{
+		$expected = "SELECT * FROM table_a LEFT JOIN table_b ON id = id";
+		$this->_parser->shouldReceive('parse')->once()->passthru();
+
+		$query = $this->_builder
+			->select("*")
+			->from('table_a')
+			->leftJoin('table_b', 'id = id', null, true)
+			->getQueryString()
+		;
+
+		$this->assertEquals($expected, trim(preg_replace('/\s+/', ' ', $query)));
+	}
+
+	public function testLeftJoinAliasWithOn()
+	{
+		$expected = "SELECT * FROM table_a LEFT JOIN table_b alias ON id = id";
+		$this->_parser->shouldReceive('parse')->once()->passthru();
+
+		$query = $this->_builder
+			->select("*")
+			->from('table_a')
+			->leftJoin('alias', 'id = id', 'table_b', true)
+			->getQueryString()
+		;
+
+		$this->assertEquals($expected, trim(preg_replace('/\s+/', ' ', $query)));
+	}
+
+	public function testLeftJoinSimpleWithUsing()
+	{
+		$expected = "SELECT * FROM table_a LEFT JOIN table_b USING (id)";
+		$this->_parser->shouldReceive('parse')->once()->passthru();
+
+		$query = $this->_builder
+			->select("*")
+			->from('table_a')
+			->leftJoin('table_b', 'id', null, false)
+			->getQueryString()
+		;
+
+		$this->assertEquals($expected, trim(preg_replace('/\s+/', ' ', $query)));
+	}
+
+	public function testLeftJoinAliasWithUsing()
+	{
+		$expected = "SELECT * FROM table_a LEFT JOIN table_b alias USING (id)";
+		$this->_parser->shouldReceive('parse')->once()->passthru();
+
+		$query = $this->_builder
+			->select("*")
+			->from('table_a')
+			->leftJoin('alias', 'id', 'table_b', false)
+			->getQueryString()
+		;
+
+		$this->assertEquals($expected, trim(preg_replace('/\s+/', ' ', $query)));
+	}
+
+	public function testLeftJoinOnSimple()
+	{
+		$expected = "SELECT * FROM table_a LEFT JOIN table_b ON id = id";
+		$this->_parser->shouldReceive('parse')->once()->passthru();
+
+		$query = $this->_builder
+			->select("*")
+			->from('table_a')
+			->leftJoinOn('table_b', 'id = id')
+			->getQueryString()
+		;
+
+		$this->assertEquals($expected, trim(preg_replace('/\s+/', ' ', $query)));
+	}
+
+	public function testLeftJoinOnAlias()
+	{
+		$expected = "SELECT * FROM table_a LEFT JOIN table_b alias ON id = id";
+		$this->_parser->shouldReceive('parse')->once()->passthru();
+
+		$query = $this->_builder
+			->select("*")
+			->from('table_a')
+			->leftJoinOn('alias', 'id = id', 'table_b')
+			->getQueryString()
+		;
+
+		$this->assertEquals($expected, trim(preg_replace('/\s+/', ' ', $query)));
+	}
+
+	public function testLeftJoinUsingSimple()
+	{
+		$expected = "SELECT * FROM table_a LEFT JOIN table_b USING (id)";
+		$this->_parser->shouldReceive('parse')->once()->passthru();
+
+		$query = $this->_builder
+			->select("*")
+			->from('table_a')
+			->leftJoinUsing('table_b', 'id')
+			->getQueryString()
+		;
+
+		$this->assertEquals($expected, trim(preg_replace('/\s+/', ' ', $query)));
+	}
+
+	public function testLeftJoinUsingAlias()
+	{
+		$expected = "SELECT * FROM table_a LEFT JOIN table_b alias USING (id)";
+		$this->_parser->shouldReceive('parse')->once()->passthru();
+
+		$query = $this->_builder
+			->select("*")
+			->from('table_a')
+			->leftJoinUsing('alias', 'id', 'table_b')
 			->getQueryString()
 		;
 


### PR DESCRIPTION
Resolves https://github.com/mothership-ec/cog/issues/438

This PR allows developers to use `USING` clauses when joining with the query builder, as well as be explicit about which clause to use, by adding the following methods:

+ `joinUsing()` - Perform a `JOIN` with the `USING` clause
+ `joinOn()` - Perform a `JOIN` with the `ON` clause
+ `leftJoinUsing()` - Perform a `LEFT JOIN` with the `USING` clause
+ `leftJoinOn()` - Perform a `LEFT JOIN` with the `ON` clause

These methods call `join()`/`leftJoin()`, but include a new forth parameter, `$on`, which takes a boolean and defaults to `true`. If it is set to `true` the join will use the `ON` clause, and if set to false the join will use the `USING` clause