### PR TITLE
Command to uninstall database tables for a certain module

### DIFF
--- a/src/Application/Context/Console.php
+++ b/src/Application/Context/Console.php
@@ -55,6 +55,7 @@ class Console implements ContextInterface
 				new Command\MigrateReset,
 				new Command\MigrateRefresh,
 				new Command\MigrateRun,
+				new Command\MigrateUninstall,
 				new Command\DeployEvent,
 				new Command\DeployPermissions,
 				new Command\ModuleNamespace,

--- a/src/Application/Context/Console.php
+++ b/src/Application/Context/Console.php
@@ -55,7 +55,7 @@ class Console implements ContextInterface
 				new Command\MigrateReset,
 				new Command\MigrateRefresh,
 				new Command\MigrateRun,
-				new Command\MigrateUninstall,
+				new Command\MigrateModuleUninstall,
 				new Command\DeployEvent,
 				new Command\DeployPermissions,
 				new Command\ModuleNamespace,

--- a/src/Console/Command/MigrateModuleUninstall.php
+++ b/src/Console/Command/MigrateModuleUninstall.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @author  Thomas Marchant <thomas@mothership.ec>
  */
-class MigrateUninstall extends Command
+class MigrateModuleUninstall extends Command
 {
 	/**
 	 * {@inheritDoc}
@@ -22,7 +22,7 @@ class MigrateUninstall extends Command
 	protected function configure()
 	{
 		$this
-			->setName('migrate:uninstall')
+			->setName('migrate:module:uninstall')
 			->setDescription('Rolls back all migrations on for a module. Use colon delimited syntax (i.e. \'Message:Mothership:Commerce\' to uninstall commerce module).')
 			->addArgument('module_name', InputArgument::REQUIRED, 'Uninstall databases for a specific module.')
 		;

--- a/src/Console/Command/MigrateUninstall.php
+++ b/src/Console/Command/MigrateUninstall.php
@@ -9,11 +9,16 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Provides the migrate:run command. Runs new migrations for all registered
- * modules.
+ * Class MigrateUninstall
+ * @package Message\Cog\Console\Command
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
  */
 class MigrateUninstall extends Command
 {
+	/**
+	 * {@inheritDoc}
+	 */
 	protected function configure()
 	{
 		$this
@@ -23,6 +28,9 @@ class MigrateUninstall extends Command
 		;
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	protected function execute(InputInterface $input, OutputInterface $output)
 	{
 		$output->writeln('<info>Uninstalling databases for ' . $input->getArgument('module_name') . '...</info>');

--- a/src/Console/Command/MigrateUninstall.php
+++ b/src/Console/Command/MigrateUninstall.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Message\Cog\Console\Command;
+
+use Message\Cog\Console\Command;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Provides the migrate:run command. Runs new migrations for all registered
+ * modules.
+ */
+class MigrateUninstall extends Command
+{
+	protected function configure()
+	{
+		$this
+			->setName('migrate:uninstall')
+			->setDescription('Rolls back all migrations on for a module. Use colon delimited syntax (i.e. \'Message:Mothership:Commerce\' to uninstall commerce module).')
+			->addArgument('module_name', InputArgument::REQUIRED, 'Uninstall databases for a specific module.')
+		;
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output)
+	{
+		$output->writeln('<info>Uninstalling databases for ' . $input->getArgument('module_name') . '...</info>');
+
+		$this->get('migrator')->rollbackModule($input->getArgument('module_name'));
+
+		foreach ($this->get('migrator')->getNotes() as $note) {
+			$output->writeln($note);
+		}
+	}
+}

--- a/src/Migration/Adapter/MySQL/Loader.php
+++ b/src/Migration/Adapter/MySQL/Loader.php
@@ -131,6 +131,27 @@ class Loader implements LoaderInterface
 		return $results[0]->batch;
 	}
 
+	public function getByModule($moduleName)
+	{
+		$moduleName = 'cog://@' . $moduleName . '%';
+
+		$results = $this->_query->run('
+			SELECT
+				path
+			FROM
+				migration
+			WHERE
+				adapter = :adapter?s
+			AND
+				path LIKE :moduleName?s
+		', [
+			'adapter'    => 'mysql',
+			'moduleName' => $moduleName,
+		]);
+
+		return $this->_getMigrations($results);
+	}
+
 	public function resolve(File $file, $reference)
 	{
 		$basename = $file->getBasename();

--- a/src/Migration/Migrator.php
+++ b/src/Migration/Migrator.php
@@ -108,22 +108,15 @@ class Migrator {
 		$migrations = $this->_loader->getLastBatch();
 
 		return $this->_rollbackMigrations($migrations);
-
-		if (count($migrations) == 0) {
-			$this->_note('<comment>Nothing to rollback</comment>');
-
-			return count($migrations);
-		}
-
-		foreach ($migrations as $migration) {
-			$this->_runDown($migration);
-		}
-
-		$this->_displayFailures();
-
-		return count($migrations);
 	}
 
+	/**
+	 * Rollback migrations for a specific module
+	 *
+	 * @param string $moduleName    Comma delimited module name i.e. Message:Mothership:Commerce
+	 *
+	 * @return int
+	 */
 	public function rollbackModule($moduleName)
 	{
 		if (!is_string($moduleName)) {
@@ -276,6 +269,13 @@ class Migrator {
 		}
 	}
 
+	/**
+	 * Rundown an array of migrations
+	 *
+	 * @param array $migrations
+	 *
+	 * @return int
+	 */
 	private function _rollbackMigrations(array $migrations)
 	{
 		if (count($migrations) == 0) {

--- a/src/Migration/Migrator.php
+++ b/src/Migration/Migrator.php
@@ -107,6 +107,8 @@ class Migrator {
 	{
 		$migrations = $this->_loader->getLastBatch();
 
+		return $this->_rollbackMigrations($migrations);
+
 		if (count($migrations) == 0) {
 			$this->_note('<comment>Nothing to rollback</comment>');
 
@@ -120,6 +122,17 @@ class Migrator {
 		$this->_displayFailures();
 
 		return count($migrations);
+	}
+
+	public function rollbackModule($moduleName)
+	{
+		if (!is_string($moduleName)) {
+			throw new \InvalidArgumentException('Module name must be a string, ' . gettype($moduleName) . ' given');
+		}
+
+		$migrations = $this->_loader->getByModule($moduleName);
+
+		return $this->_rollbackMigrations($migrations);
 	}
 
 	/**
@@ -261,6 +274,25 @@ class Migrator {
 
 			$this->_note('<error>Could not load migration: `' . $failure . '`</error>');
 		}
+	}
+
+	private function _rollbackMigrations(array $migrations)
+	{
+		if (count($migrations) == 0) {
+			$this->_note('<comment>Nothing to rollback</comment>');
+
+			return count($migrations);
+		}
+
+		krsort($migrations);
+
+		foreach ($migrations as $migration) {
+			$this->_runDown($migration);
+		}
+
+		$this->_displayFailures();
+
+		return count($migrations);
 	}
 
 }


### PR DESCRIPTION
This PR adds a `migrate:module:uninstall` command for uninstalling tables for modules. The reason for this is that if you remove a module from the composer.json and then try to run `migrate:run`, it will error as it tries to load classes that are no longer installed
