### PR TITLE
Fixed absolute paths

### DIFF
--- a/src/AssetManagement/CssCoguleRewriteFilter.php
+++ b/src/AssetManagement/CssCoguleRewriteFilter.php
@@ -1,4 +1,6 @@
-<?php namespace Message\Cog\AssetManagement;
+<?php
+
+namespace Message\Cog\AssetManagement;
 
 use Assetic\Asset\AssetInterface;
 use Assetic\Filter\BaseCssFilter;
@@ -11,44 +13,44 @@ class CssCoguleRewriteFilter extends BaseCssFilter
 {
 
 	public function filterLoad(AssetInterface $asset)
-    {
+	{
 
-    }
+	}
 
 	public function filterDump(AssetInterface $asset)
 	{
 		$sourceBase = $asset->getSourceRoot();
-        $sourcePath = $asset->getSourcePath();
-        $targetPath = $asset->getTargetPath();
+		$sourcePath = $asset->getSourcePath();
+		$targetPath = $asset->getTargetPath();
 
-        if (null === $sourcePath || null === $targetPath || $sourcePath == $targetPath) {
-            return;
-        }
+		if (null === $sourcePath || null === $targetPath || $sourcePath == $targetPath) {
+			return;
+		}
 
-        $cogNamespace = $asset->cogNamespace;
+		$cogNamespace = $asset->cogNamespace;
 
-        $content = $this->filterReferences($asset->getContent(), function($matches) use ($cogNamespace) {
-            if (false !== strpos($matches['url'], '://') || 0 === strpos($matches['url'], '//') || 0 === strpos($matches['url'], 'data:')) {
-                // absolute or protocol-relative or data uri
-                return $matches[0];
-            }
+		$content = $this->filterReferences($asset->getContent(), function($matches) use ($cogNamespace) {
+			if (false !== strpos($matches['url'], '://') || 0 === strpos($matches['url'], '//') || 0 === strpos($matches['url'], 'data:')) {
+				// absolute or protocol-relative or data uri
+				return $matches[0];
+			}
 
-            if (isset($matches['url'][0]) && '/' == $matches['url'][0]) {
-                // root relative
-                return $matches[0];
-            }
+			if (isset($matches['url'][0]) && '/' == $matches['url'][0]) {
+				// root relative
+				return $matches[0];
+			}
 
-            $url = $matches['url'];
-            while (0 === strpos($url, '../')) {
-                $url = substr($url, 3);
-            }
+			$url = $matches['url'];
+			while (0 === strpos($url, '../')) {
+				$url = substr($url, 3);
+			}
 
-            $url = '../../cogules/' . $cogNamespace . '/' . $url;
+			$url = '../../cogules/' . $cogNamespace . '/' . $url;
 
-        	return str_replace($matches['url'], $url, $matches[0]);
-        });
+			return str_replace($matches['url'], $url, $matches[0]);
+		});
 
-        $asset->setContent($content);
+		$asset->setContent($content);
 	}
 
 }

--- a/src/AssetManagement/CssCoguleRewriteFilter.php
+++ b/src/AssetManagement/CssCoguleRewriteFilter.php
@@ -30,13 +30,11 @@ class CssCoguleRewriteFilter extends BaseCssFilter
 		$cogNamespace = $asset->cogNamespace;
 
 		$content = $this->filterReferences($asset->getContent(), function($matches) use ($cogNamespace) {
-			if (false !== strpos($matches['url'], '://') || 0 === strpos($matches['url'], '//') || 0 === strpos($matches['url'], 'data:')) {
+			if (false !== strpos($matches['url'], '://') ||
+				0 === strpos($matches['url'], '//') ||
+				0 === strpos($matches['url'], 'data:') ||
+				isset($matches['url'][0]) && '/' == $matches['url'][0]) {
 				// absolute or protocol-relative or data uri
-				return $matches[0];
-			}
-
-			if (isset($matches['url'][0]) && '/' == $matches['url'][0]) {
-				// root relative
 				return $matches[0];
 			}
 

--- a/src/AssetManagement/CssCoguleRewriteFilter.php
+++ b/src/AssetManagement/CssCoguleRewriteFilter.php
@@ -28,14 +28,14 @@ class CssCoguleRewriteFilter extends BaseCssFilter
         $cogNamespace = $asset->cogNamespace;
 
         $content = $this->filterReferences($asset->getContent(), function($matches) use ($cogNamespace) {
-        	if (false !== strpos($matches['url'], '://') || 0 === strpos($matches['url'], '//') || 0 === strpos($matches['url'], 'data:')) {
+            if (false !== strpos($matches['url'], '://') || 0 === strpos($matches['url'], '//') || 0 === strpos($matches['url'], 'data:')) {
                 // absolute or protocol-relative or data uri
                 return $matches[0];
             }
 
             if (isset($matches['url'][0]) && '/' == $matches['url'][0]) {
                 // root relative
-                return str_replace($matches['url'], $host.$matches['url'], $matches[0]);
+                return $matches[0];
             }
 
             $url = $matches['url'];

--- a/tests/AssetManagement/CssCoguleRewriteFilter.php
+++ b/tests/AssetManagement/CssCoguleRewriteFilter.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Message\Cog\Test\AssetManagement;
+
+use Message\Cog\AssetManagement\CssCoguleRewriteFilter as Filter;
+use Mockery as m;
+
+class CssCoguleRewriteFilter extends \PHPUnit_Framework_TestCase
+{
+	
+	public function testRelativePath() {
+		$asset = m::mock('\\Assetic\\Asset\\AssetInterface')
+			->shouldReceive('getSourceRoot')
+			->zeroOrMoreTimes()
+			->andReturn('/test')
+
+			->shouldReceive('getSourcePath')
+			->zeroOrMoreTimes()
+			->andReturn('test')
+
+			->shouldReceive('getTargetPath')
+			->zeroOrMoreTimes()
+			->andReturn('/test/target')
+
+			->shouldReceive('getContent')
+			->once()
+			->andReturn("url('../image.jpg')")
+
+			->shouldReceive('setContent')
+			->with('url(\'../../cogules/Test:Module/image.jpg\')')
+			->once()
+
+			->getMock()
+		;
+
+		$asset->cogNamespace = 'Test:Module';
+
+		$filter = new Filter;
+
+		$filter->filterDump($asset);
+	}
+
+	public function testAbsolutePath() {
+		$asset = m::mock('\\Assetic\\Asset\\AssetInterface')
+			->shouldReceive('getSourceRoot')
+			->zeroOrMoreTimes()
+			->andReturn('/test')
+
+			->shouldReceive('getSourcePath')
+			->zeroOrMoreTimes()
+			->andReturn('test')
+
+			->shouldReceive('getTargetPath')
+			->zeroOrMoreTimes()
+			->andReturn('/test/target')
+
+			->shouldReceive('getContent')
+			->once()
+			->andReturn("url('/image.jpg')")
+
+			->shouldReceive('setContent')
+			->with('url(\'/image.jpg\')')
+			->once()
+
+			->getMock()
+		;
+
+		$asset->cogNamespace = 'Test:Module';
+
+		$filter = new Filter;
+
+		$filter->filterDump($asset);
+	}
+}

--- a/tests/AssetManagement/CssCoguleRewriteFilter.php
+++ b/tests/AssetManagement/CssCoguleRewriteFilter.php
@@ -71,4 +71,36 @@ class CssCoguleRewriteFilter extends \PHPUnit_Framework_TestCase
 
 		$filter->filterDump($asset);
 	}
+
+	public function testAbsolutePathWithProtocol() {
+		$asset = m::mock('\\Assetic\\Asset\\AssetInterface')
+			->shouldReceive('getSourceRoot')
+			->zeroOrMoreTimes()
+			->andReturn('/test')
+
+			->shouldReceive('getSourcePath')
+			->zeroOrMoreTimes()
+			->andReturn('test')
+
+			->shouldReceive('getTargetPath')
+			->zeroOrMoreTimes()
+			->andReturn('/test/target')
+
+			->shouldReceive('getContent')
+			->once()
+			->andReturn("url('http://image.jpg')")
+
+			->shouldReceive('setContent')
+			->with('url(\'http://image.jpg\')')
+			->once()
+
+			->getMock()
+		;
+
+		$asset->cogNamespace = 'Test:Module';
+
+		$filter = new Filter;
+
+		$filter->filterDump($asset);
+	}
 }


### PR DESCRIPTION
Fixes #456.

Only relative paths should be rewritten to ../cogules/.... I think the original intention was for urls like '/example/url' would be rewritten to 'http://my-website.com/example/url' however this isn't necessary as that's how abs paths work anyway.

Test by changing some paths in the css to this format and then refreshing with asset generation on. It will error without this change as described in the issue.