### PR TITLE
Use ABSOLUTE_URL constant on URL generation, closes #345

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -129,12 +129,12 @@ class Controller implements ContainerAwareInterface, RequestAwareInterface
 	 *
 	 * @param string         $routeName     Name of the route to use
 	 * @param array          $params        Parameters to use in the route
-	 * @param boolean|string $referenceType The type of reference (one of the
+	 * @param boolean|string $absolute The type of reference (one of the
 	 *                                      constants in UrlGeneratorInterface)
 	 *
 	 * @return string            The generated URL
 	 */
-	public function generateUrl($routeName, $params = array(), $absolute = UrlGeneratorInterface::ABSOLUTE_PATH)
+	public function generateUrl($routeName, $params = array(), $absolute = UrlGeneratorInterface::ABSOLUTE_URL)
 	{
 		return $this->_services['routing.generator']->generate($routeName, $params, $absolute);
 	}

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -127,10 +127,10 @@ class Controller implements ContainerAwareInterface, RequestAwareInterface
 	 *
 	 * @see \Message\Cog\Routing\UrlGenerator::generate()
 	 *
-	 * @param string         $routeName     Name of the route to use
-	 * @param array          $params        Parameters to use in the route
-	 * @param boolean|string $absolute The type of reference (one of the
-	 *                                      constants in UrlGeneratorInterface)
+	 * @param string             $routeName     Name of the route to use
+	 * @param array              $params        Parameters to use in the route
+	 * @param boolean|string     $absolute      The type of reference (one of the
+	 *                                          constants in UrlGeneratorInterface)
 	 *
 	 * @return string            The generated URL
 	 */


### PR DESCRIPTION
This PR resolves issue #345.

To test this I checked that the following worked:

+ Links on front end
+ Links in admin panel
+ Links sent to flash messages (e.g. when deleting a page or change a flash message to one from a deleted page)
+ Submitting forms with an action set