### PR TITLE
Bootstrap directory no longer required in modules

### DIFF
--- a/src/Bootstrap/Loader.php
+++ b/src/Bootstrap/Loader.php
@@ -7,8 +7,6 @@ use Message\Cog\Service\ContainerInterface;
 use Message\Cog\Service\ContainerAwareInterface;
 use Message\Cog\HTTP\RequestAwareInterface;
 
-use RuntimeException;
-
 /**
  * Bootstrap loader, responsible for loading bootstraps from modules or Cog
  * itself.
@@ -43,8 +41,6 @@ class Loader implements LoaderInterface
 	 *
 	 * @param  string $path      The directory to load from
 	 * @param  string $namespace The namespace for this directory
-	 *
-	 * @throws RuntimeException  If the given path does not exist or is not a directory
 	 *
 	 * @return Loader            Returns $this for chaining
 	 */

--- a/src/Bootstrap/Loader.php
+++ b/src/Bootstrap/Loader.php
@@ -41,6 +41,9 @@ class Loader implements LoaderInterface
 	 *
 	 * @param  string $path      The directory to load from
 	 * @param  string $namespace The namespace for this directory
+	 * @throws \RuntimeException Throws exception if $path is not a directory
+	 * @throws \RuntimeException Throws exception if $path not readable
+	 * @throws \RuntimeException Throws exception if $path not executable
 	 *
 	 * @return Loader            Returns $this for chaining
 	 */

--- a/src/Bootstrap/Loader.php
+++ b/src/Bootstrap/Loader.php
@@ -50,8 +50,8 @@ class Loader implements LoaderInterface
 	 */
 	public function addFromDirectory($path, $namespace)
 	{
-		if (!file_exists($path) or !is_dir($path)) {
-			throw new RuntimeException(sprintf('No bootstrap directory found at %s', $path));
+		if (!file_exists($path) || !is_dir($path)) {
+			return $this;
 		}
 
 		// Check the leading namespace slash is there

--- a/src/Bootstrap/Loader.php
+++ b/src/Bootstrap/Loader.php
@@ -46,8 +46,16 @@ class Loader implements LoaderInterface
 	 */
 	public function addFromDirectory($path, $namespace)
 	{
-		if (!file_exists($path) || !is_dir($path)) {
+		if (!file_exists($path)) {
 			return $this;
+		}
+
+		if (!is_dir($path)) {
+			throw new \RuntimeException('`' . $path . '` exists, but is not a directory');
+		}
+
+		if (!is_readable($path) || !is_executable($path)) {
+			throw new \RuntimeException('Bootstrap directory `' . $path . '` is not readable');
 		}
 
 		// Check the leading namespace slash is there

--- a/src/Module/Loader.php
+++ b/src/Module/Loader.php
@@ -93,27 +93,21 @@ class Loader implements LoaderInterface
 	protected function _loadModules()
 	{
 		foreach ($this->_modules as $module) {
-			try {
-				// Load the bootstraps
-				$this->_bootstrapLoader
-					->addFromDirectory(
-						$this->_locator->getPath($module) . 'Bootstrap',
-						$module . '\\Bootstrap'
-					);
-
-				// Fire the "module loaded" event
-				$this->_eventDispatcher->dispatch(
-					sprintf(
-						'module.%s.load.success',
-						strtolower(str_replace('\\', '.', $module))
-					),
-					new Event
+			// Load the bootstraps
+			$this->_bootstrapLoader
+				->addFromDirectory(
+					$this->_locator->getPath($module) . 'Bootstrap',
+					$module . '\\Bootstrap'
 				);
-			} catch (\RuntimeException $e) {
-				// Catch and log an exception if the directory is not found, to
-				// allow the application to continue since this is not fatal.
-				$this->_logger->warning($e->getMessage());
-			}
+
+			// Fire the "module loaded" event
+			$this->_eventDispatcher->dispatch(
+				sprintf(
+					'module.%s.load.success',
+					strtolower(str_replace('\\', '.', $module))
+				),
+				new Event
+			);
 		}
 
 		$this->_bootstrapLoader->load();

--- a/tests/Bootstrap/LoaderTest.php
+++ b/tests/Bootstrap/LoaderTest.php
@@ -3,7 +3,6 @@
 namespace Message\Cog\Test\Bootstrap;
 
 use Message\Cog\Bootstrap\Loader;
-use Message\Cog\HTTP\Request;
 
 use Message\Cog\Test\Application\FauxEnvironment;
 use Message\Cog\Test\Service\FauxContainer;
@@ -130,5 +129,40 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
 
 		// Test the bootstraps were cleared from the loader
 		$this->assertEmpty($this->_loader->getBootstraps());
+	}
+
+	public function testAddFromDirectoryNotExists()
+	{
+		$loader = $this->_loader->addFromDirectory('non-existent', 'Mothership\\Site');
+
+		$this->assertSame($loader, $this->_loader);
+	}
+
+	/**
+	 * @expectedException \RuntimeException
+	 */
+	public function testAddFromDirectoryNotDirectory()
+	{
+		$this->_loader->addFromDirectory(__FILE__, 'Mothership\\Site');
+	}
+
+	/**
+	 * @expectedException \RuntimeException
+	 */
+	public function testAddFromDirectoryUnexecutable()
+	{
+		$path = __DIR__ . '/test-exec';
+		$perm = 0666;
+		if (!is_dir(__DIR__ . '/test-exec')) {
+			mkdir($path, $perm);
+		}
+
+		if (is_executable($path)) {
+			@chmod($path, $perm);
+		}
+
+		$this->_loader->addFromDirectory($path, 'Mothership\\Site');
+
+		@rmdir($path);
 	}
 }


### PR DESCRIPTION
This PR makes it so that the Bootstrap loader no longer throws an exception if the Bootstrap directory does not exist in a module, resolves #362 

I tested this by creating a test module in a Mothership site and adding an interface that extends the ServicesInterface, then making the main service container implement that instead