### PR TITLE
Deprecate/remove service:list command

### DIFF
--- a/src/Application/Bootstrap/Services.php
+++ b/src/Application/Bootstrap/Services.php
@@ -353,25 +353,6 @@ class Services implements ServicesInterface
 			return new \Symfony\Component\HttpKernel\UriSigner(time());
 		};
 
-		$services['http.rest.request_dispatcher_collection'] = function($c)
-		{
-			return new Cog\HTTP\REST\RequestDispatcherCollection([
-				$c['http.rest.xml_request_dispatcher'],
-			]);
-		};
-
-		$services['http.rest.xml_request_dispatcher'] = function($c)
-		{
-			return new Cog\HTTP\REST\XmlRequestDispatcher(
-				$c['http.kernel'],
-				$c['serializer.array_to_xml']
-			);
-		};
-
-		$services['http.oauth.factory'] = function($c) {
-			return new Cog\HTTP\OAuth\Factory;
-		};
-
 		$services['response_builder'] = function($c) {
 			return new Cog\Controller\ResponseBuilder(
 				$c['templating']

--- a/src/Application/Context/Console.php
+++ b/src/Application/Context/Console.php
@@ -41,7 +41,6 @@ class Console implements ContextInterface
 				new Command\ModuleList,
 				new Command\RouteList,
 				new Command\RouteCollectionTree,
-				new Command\ServiceList,
 				new Command\Setup,
 				new Command\Status,
 				new Command\TaskGenerate,

--- a/src/Console/Command/ServiceList.php
+++ b/src/Console/Command/ServiceList.php
@@ -13,6 +13,10 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * Provides the services:list command.
  * List all registered services.
+ *
+ * @deprecated This class is deprecated because it is too unstable to use in practice. It loads every single
+ *             service in the service container, but if any have issues the whole script will break. This makes
+ *             it better as a tool for debugging but not very useful as a way to list services.
  */
 class ServiceList extends Command
 {


### PR DESCRIPTION
This PR removes the `services:list` command from the command list, and deprecates the class. The reason for this is that it was too unstable as it would load every single service, but some services might not have been registered yet as they are only registered in events. Also if any services error for any other reason, it breaks. The command itself is not actually very useful so I don't think it's a great loss. Resolves https://github.com/mothership-ec/cog/issues/328

It also removes a couple unused services for classes that don't exist.