### PR TITLE
Do not show task output twice, resolves #332

### DIFF
--- a/src/Console/Task/Runner.php
+++ b/src/Console/Task/Runner.php
@@ -43,9 +43,6 @@ class Runner
 		$command->addOutputHandler($mail);
 		$command->addOutputHandler($log);
 
-		// Output to the console by default
-		$command->output('print')->enable();
-
 		$app->add($command);
 		$app->setAutoExit(false);
 

--- a/src/Console/Task/Task.php
+++ b/src/Console/Task/Task.php
@@ -24,6 +24,8 @@ abstract class Task extends Command
 	protected $_outputHandlers   = array();
 	protected $_buffer           = '';
 
+	protected $_output;
+
 	final public function __construct($name)
 	{
 		parent::__construct($name);


### PR DESCRIPTION
The `print` output was automatically enabled, even though the `writeln()` method would already print the output to the terminal in real time. This removes that setting, and it also adds the missing `$_output` property to the base `Task` class