### PR TITLE
Add deprecation docblocks to Form\Handler and Validation component

### DIFF
--- a/src/Form/Handler.php
+++ b/src/Form/Handler.php
@@ -15,7 +15,7 @@ use Message\Cog\Service\Container;
  * use of private properties and methods, as well as the labyrinthian structure of the component. This class is
  * designed to create an instance of the form and of the validator, and allow them to work together.
  *
- * @todo when adding a select field, make sure validation removes any fields that aren't in the list
+ * @deprecated Forms should not be built using this class. Use vanilla Symfony form instead
  *
  * @author Thomas Marchant <thomas@message.co.uk>
  */

--- a/src/Form/readme.md
+++ b/src/Form/readme.md
@@ -172,6 +172,8 @@ To display the entity in the form view, the `property`-option is used to determi
 
 # Deprecated Form Component
 
+**This component is deprecated, do not create new forms using this component!**
+
 The form integrates the Symfony Form component with the rest of the framework, specifically templating and validation.
 
 Due to the complexity of the Symfony Form component, and the fact that many of the classes have several private properties and methods, the majority of the classes are not extended. As a result, we must use a handler to use the Form and Validation components together.

--- a/src/Validation/CollectionInterface.php
+++ b/src/Validation/CollectionInterface.php
@@ -8,6 +8,8 @@ namespace Message\Cog\Validation;
  *
  * Interface for creating collections for data to be parsed to for validation
  *
+ * @deprecated Do not use this component, use Symfony's validation component instead
+ *
  * @author James Moss <james@message.co.uk>
  * @author Thomas Marchant <thomas@message.co.uk>
  */

--- a/src/Validation/Field.php
+++ b/src/Validation/Field.php
@@ -6,6 +6,8 @@ namespace Message\Cog\Validation;
  * Validator
  * @package Message\Cog\Validation
  *
+ * @deprecated Do not use this component, use Symfony's validation component instead
+ *
  * @author Iris Schaffer <iris@message.co.uk>
  */
 class Field

--- a/src/Validation/Filter/Number.php
+++ b/src/Validation/Filter/Number.php
@@ -5,6 +5,12 @@ namespace Message\Cog\Validation\Filter;
 use Message\Cog\Validation\CollectionInterface;
 use Message\Cog\Validation\Loader;
 
+/**
+ * Class Number
+ * @package Message\Cog\Validation\Filter
+ *
+ * @deprecated Do not use this component, use Symfony's validation component instead
+ */
 class Number implements CollectionInterface
 {
 	/**

--- a/src/Validation/Filter/Other.php
+++ b/src/Validation/Filter/Other.php
@@ -11,6 +11,8 @@ use Message\Cog\Validation\Loader;
  *
  * Parse variables through callables such as native PHP functions
  *
+ * @deprecated Do not use this component, use Symfony's validation component instead
+ *
  * @author James Moss <james@message.co.uk>
  * @author Thomas Marchant <thomas@message.co.uk>
  */

--- a/src/Validation/Filter/Text.php
+++ b/src/Validation/Filter/Text.php
@@ -12,6 +12,8 @@ use Message\Cog\Functions\Text as TextFunction;
  *
  * Casts fields through string filters
  *
+ * @deprecated Do not use this component, use Symfony's validation component instead
+ *
  * @author James Moss <james@message.co.uk>
  * @author Thomas Marchant <thomas@message.co.uk>
  */

--- a/src/Validation/Filter/Type.php
+++ b/src/Validation/Filter/Type.php
@@ -11,6 +11,8 @@ use Message\Cog\Validation\Loader;
  *
  * Casts fields to specific data types.
  *
+ * @deprecated Do not use this component, use Symfony's validation component instead
+ *
  * @author James Moss <james@message.co.uk>
  * @author Thomas Marchant <thomas@message.co.uk>
  */

--- a/src/Validation/Loader.php
+++ b/src/Validation/Loader.php
@@ -8,6 +8,8 @@ namespace Message\Cog\Validation;
  *
  * Loads and maintains a set of rules and filters to use in validation
  *
+ * @deprecated Do not use this component, use Symfony's validation component instead
+ *
  * @author James Moss <james@message.co.uk>
  * @author Thomas Marchant <thomas@message.co.uk>
  */

--- a/src/Validation/Messages.php
+++ b/src/Validation/Messages.php
@@ -8,6 +8,8 @@ namespace Message\Cog\Validation;
  *
  * Stores and manages error messages for validation
  *
+ * @deprecated Do not use this component, use Symfony's validation component instead
+ *
  * @author James Moss <james@message.co.uk>
  * @author Thomas Marchant <thomas@message.co.uk>
  */

--- a/src/Validation/Rule/Date.php
+++ b/src/Validation/Rule/Date.php
@@ -11,6 +11,8 @@ use Message\Cog\Validation\Loader;
  *
  * Class used to validating and comparing dates.
  *
+ * @deprecated Do not use this component, use Symfony's validation component instead
+ *
  * @author James Moss <james@message.co.uk>
  * @author Thomas Marchant <thomas@message.co.uk>
  */

--- a/src/Validation/Rule/Iterable.php
+++ b/src/Validation/Rule/Iterable.php
@@ -12,7 +12,7 @@ use Message\Cog\Validation\Loader;
  *
  * Class for looping through values for validation
  *
- * @todo get working
+ * @deprecated Do not use this component, use Symfony's validation component instead
  *
  * @author James Moss <james@message.co.uk>
  * @author Thomas Marchant <thomas@message.co.uk>

--- a/src/Validation/Rule/Number.php
+++ b/src/Validation/Rule/Number.php
@@ -11,6 +11,8 @@ use Message\Cog\Validation\Loader;
  *
  * Validating numeric values
  *
+ * @deprecated Do not use this component, use Symfony's validation component instead
+ *
  * @author James Moss <james@message.co.uk>
  * @author Thomas Marchant <thomas@message.co.uk>
  */

--- a/src/Validation/Rule/Other.php
+++ b/src/Validation/Rule/Other.php
@@ -11,6 +11,8 @@ use Message\Cog\Validation\Loader;
  *
  * Can use callables such as native PHP functions to validate inputs
  *
+ * @deprecated Do not use this component, use Symfony's validation component instead
+ *
  * @author James Moss <james@message.co.uk>
  * @author Thomas Marchant <thomas@message.co.uk>
  */

--- a/src/Validation/Rule/Text.php
+++ b/src/Validation/Rule/Text.php
@@ -11,6 +11,8 @@ use Message\Cog\Validation\Loader;
  *
  * Validating text inputs
  *
+ * @deprecated Do not use this component, use Symfony's validation component instead
+ *
  * @author James Moss <james@message.co.uk>
  * @author Thomas Marchant <thomas@message.co.uk>
  */

--- a/src/Validation/Rule/Type.php
+++ b/src/Validation/Rule/Type.php
@@ -10,6 +10,8 @@ use Message\Cog\Validation\Loader;
  * @package Message\Cog\Validation\Rule
  *
  * Class used to validating and comparing types.
+ *
+ * @deprecated Do not use this component, use Symfony's validation component instead
  */
 class Type implements CollectionInterface
 {

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -8,6 +8,8 @@ namespace Message\Cog\Validation;
  *
  * A wrapper around Respect\Validation which makes using it easier
  *
+ * @deprecated Do not use this component, use Symfony's validation component instead
+ *
  * @author James Moss <james@message.co.uk>
  * @author Thomas Marchant <thomas@message.co.uk>
  */


### PR DESCRIPTION
These classes have been deprecated since the dawn of time, but there was nothing telling you that they were except for the readmes. I've added deprecation messages to the docblocks