### PR TITLE
Filter out non-unique flash messages

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -58,9 +58,8 @@ class Controller implements ContainerAwareInterface, RequestAwareInterface
 
 		// Filter out duplicate messages
 		$flashes = $this->get('http.session')->getFlashBag()->peekAll();
-		foreach ($flashes as $type => $messages) {
-			$flashes[$type] = array_unique($messages);
-		}
+
+		$flashes[$type] = array_unique($flashes[$type]);
 
 		// Replace flash messages with filtered set and return
 		return $this->get('http.session')->getFlashBag()->setAll($flashes);

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -54,8 +54,14 @@ class Controller implements ContainerAwareInterface, RequestAwareInterface
 	public function addFlash($type, $message, array $params = [])
 	{
 		$message = $this->trans($message, $params);
+		$this->get('http.session')->getFlashBag()->add($type, $message);
+		$flashes = $this->get('http.session')->getFlashBag()->peekAll();
 
-		return $this->get('http.session')->getFlashBag()->add($type, $message);
+		foreach ($flashes as $type => $messages) {
+			$flashes[$type] = array_unique($messages);
+		}
+
+		return $this->get('http.session')->getFlashBag()->setAll($flashes);
 	}
 
 	/**

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -55,12 +55,14 @@ class Controller implements ContainerAwareInterface, RequestAwareInterface
 	{
 		$message = $this->trans($message, $params);
 		$this->get('http.session')->getFlashBag()->add($type, $message);
-		$flashes = $this->get('http.session')->getFlashBag()->peekAll();
 
+		// Filter out duplicate messages
+		$flashes = $this->get('http.session')->getFlashBag()->peekAll();
 		foreach ($flashes as $type => $messages) {
 			$flashes[$type] = array_unique($messages);
 		}
 
+		// Replace flash messages with filtered set and return
 		return $this->get('http.session')->getFlashBag()->setAll($flashes);
 	}
 


### PR DESCRIPTION
This PR removes duplicate flash messages. This should make things a bit cleaner, especially if multiple requests have been sent before the page has rendered (i.e. if you mash a button multiple times)