### PR TITLE
Translation exceptions

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -37,6 +37,9 @@
 		<testsuite name="Event">
 			<directory>./tests/Event/</directory>
 		</testsuite>
+        <testsuite name="ExceptionTest"> <!-- Exception is a reserved word so must be ExceptionTest -->
+            <directory>./tests/Exception/</directory>
+        </testsuite>
         <testsuite name="Field">
             <directory>./tests/Field/</directory>
         </testsuite>

--- a/src/Exception/TranslationExceptionInterface.php
+++ b/src/Exception/TranslationExceptionInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Message\Cog\Exception;
+
+/**
+ * Interface TranslationExceptionInterface
+ * @package Message\Cog\Exception
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ *
+ * Interface for exceptions that can take a translation string as a second parameter, for use in
+ * user-facing error messages. To access the translation string, call `getTranslation()`
+ */
+interface TranslationExceptionInterface
+{
+	/**
+	 * Identical to \Exception constructor, except the second parameter is the translation string. The
+	 * remaining constructor arguments ($code and $previous) are moved along to third and forth.
+	 *
+	 * @param string $message
+	 * @param null $translation
+	 * @param int $code
+	 * @param \Exception $previous
+	 */
+	public function __construct($message = "", $translation = null, $code = 0, \Exception $previous = null);
+
+	/**
+	 * Set the translation string for the exception.
+	 *
+	 * @param string $translation
+	 */
+	public function setTranslation($translation);
+
+	/**
+	 * Get the translation string for the exception
+	 *
+	 * @return string
+	 */
+	public function getTranslation();
+}

--- a/src/Exception/TranslationExceptionInterface.php
+++ b/src/Exception/TranslationExceptionInterface.php
@@ -9,7 +9,8 @@ namespace Message\Cog\Exception;
  * @author  Thomas Marchant <thomas@mothership.ec>
  *
  * Interface for exceptions that can take a translation string as a second parameter, for use in
- * user-facing error messages. To access the translation string, call `getTranslation()`
+ * user-facing error messages. It takes a third parameter for translation parameters. The `code`
+ * and `previous` parameters have been moved to forth and fifth respectively.
  */
 interface TranslationExceptionInterface
 {
@@ -19,10 +20,17 @@ interface TranslationExceptionInterface
 	 *
 	 * @param string $message
 	 * @param null $translation
+	 * @param array $params
 	 * @param int $code
 	 * @param \Exception $previous
 	 */
-	public function __construct($message = "", $translation = null, $code = 0, \Exception $previous = null);
+	public function __construct(
+		$message = "",
+		$translation = null,
+		$params = [],
+		$code = 0,
+		\Exception $previous = null
+	);
 
 	/**
 	 * Set the translation string for the exception.

--- a/src/Exception/TranslationExceptionTrait.php
+++ b/src/Exception/TranslationExceptionTrait.php
@@ -18,6 +18,11 @@ trait TranslationExceptionTrait
 	private $_translation;
 
 	/**
+	 * @var
+	 */
+	private $_params = [];
+
+	/**
 	 * @see TranslationExceptionInterface::setTranslation()
 	 * {@inheritDoc}
 	 */
@@ -37,5 +42,15 @@ trait TranslationExceptionTrait
 	public function getTranslation()
 	{
 		return $this->_translation ?: $this->getMessage();
+	}
+
+	public function setParams(array $params)
+	{
+		$this->_params = $params;
+	}
+
+	public function getParams()
+	{
+		return $this->_params;
 	}
 }

--- a/src/Exception/TranslationExceptionTrait.php
+++ b/src/Exception/TranslationExceptionTrait.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Message\Cog\Exception;
+
+/**
+ * Class TranslationExceptionTrait
+ * @package Message\Cog\Exception
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ *
+ * Trait for duplicating translation functionality across translation exceptions
+ */
+trait TranslationExceptionTrait
+{
+	/**
+	 * @var string
+	 */
+	private $_translation;
+
+	/**
+	 * @see TranslationExceptionInterface::setTranslation()
+	 * {@inheritDoc}
+	 */
+	public function setTranslation($translation)
+	{
+		if (!is_string($translation)) {
+			throw new \InvalidArgumentException('Translation must be a string!');
+		}
+
+		$this->_translation = $translation;
+	}
+
+	/**
+	 * @see TranslationExceptionInterface::getTranslation()
+	 * {@inheritDoc}
+	 */
+	public function getTranslation()
+	{
+		return $this->_translation ?: $this->getMessage();
+	}
+}

--- a/src/Exception/TranslationLogicException.php
+++ b/src/Exception/TranslationLogicException.php
@@ -23,6 +23,7 @@ class TranslationLogicException extends \LogicException implements TranslationEx
 	public function __construct(
 		$message = "",
 		$translation = null,
+		$params = [],
 		$code = 0,
 		\Exception $previous = null
 	)
@@ -30,6 +31,8 @@ class TranslationLogicException extends \LogicException implements TranslationEx
 		if (null !== $translation) {
 			$this->setTranslation($translation);
 		}
+
+		$this->setParams($params);
 
 		parent::__construct($message, $code, $previous);
 	}

--- a/src/Exception/TranslationLogicException.php
+++ b/src/Exception/TranslationLogicException.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Message\Cog\Exception;
+
+/**
+ * Class TranslationLogicException
+ * @package Message\Cog\Exception
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ *
+ * Logic exception to allow for translation strings to be given to an exception for user-facing error
+ * messages.
+ *
+ * @see TranslationExceptionInterface
+ */
+class TranslationLogicException extends \LogicException implements TranslationExceptionInterface
+{
+	use TranslationExceptionTrait;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function __construct(
+		$message = "",
+		$translation = null,
+		$code = 0,
+		\Exception $previous = null
+	)
+	{
+		if (null !== $translation) {
+			$this->setTranslation($translation);
+		}
+
+		parent::__construct($message, $code, $previous);
+	}
+}

--- a/src/Exception/TranslationRuntimeException.php
+++ b/src/Exception/TranslationRuntimeException.php
@@ -23,6 +23,7 @@ class TranslationRuntimeException extends \RuntimeException implements Translati
 	public function __construct(
 		$message = "",
 		$translation = null,
+		$params = [],
 		$code = 0,
 		\Exception $previous = null
 	)
@@ -30,6 +31,8 @@ class TranslationRuntimeException extends \RuntimeException implements Translati
 		if (null !== $translation) {
 			$this->setTranslation($translation);
 		}
+
+		$this->setParams($params);
 
 		parent::__construct($message, $code, $previous);
 	}

--- a/src/Exception/TranslationRuntimeException.php
+++ b/src/Exception/TranslationRuntimeException.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Message\Cog\Exception;
+
+/**
+ * Class TranslationRuntimeException
+ * @package Message\Cog\Exception
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ *
+ * Runtime exception to allow for translation strings to be given to an exception for user-facing error
+ * messages.
+ *
+ * @see TranslationExceptionInterface
+ */
+class TranslationRuntimeException extends \RuntimeException implements TranslationExceptionInterface
+{
+	use TranslationExceptionTrait;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function __construct(
+		$message = "",
+		$translation = null,
+		$code = 0,
+		\Exception $previous = null
+	)
+	{
+		if (null !== $translation) {
+			$this->setTranslation($translation);
+		}
+
+		parent::__construct($message, $code, $previous);
+	}
+}

--- a/tests/Exception/TranslationLogicExceptionTest.php
+++ b/tests/Exception/TranslationLogicExceptionTest.php
@@ -45,6 +45,44 @@ class TranslationLogicExceptionTest extends \PHPUnit_Framework_TestCase
 		$this->assertSame($translation, $exception->getTranslation());
 	}
 
+	public function testGetParamsFromConstruct()
+	{
+		$params = ['foo' => 'bar'];
+		$exception = new TranslationLogicException('Message', 'translation', $params);
+		$this->assertSame($params, $exception->getParams());
+	}
+
+	public function testGetParamsFromSetParams()
+	{
+		$params = ['foo' => 'bar'];
+		$exception = new TranslationLogicException('Message');
+		$exception->setParams($params);
+		$this->assertSame($params, $exception->getParams());
+	}
+
+	public function testGetParamsDefaultToEmptyArray()
+	{
+		$exception = new TranslationLogicException;
+		$this->assertSame([], $exception->getParams());
+	}
+
+	public function testSetParamsOverrideConstruct()
+	{
+		$params = ['baz' => 'bing'];
+		$exception = new TranslationLogicException('Message', 'translation', ['foo' => 'bar']);
+		$exception->setParams($params);
+		$this->assertSame($params, $exception->getParams());
+	}
+
+	public function testSetParamsOverrideSetParams()
+	{
+		$params = ['baz' => 'bing'];
+		$exception = new TranslationLogicException;
+		$exception->setParams(['foo' => 'bar']);
+		$exception->setParams($params);
+		$this->assertSame($params, $exception->getParams());
+	}
+
 	/**
 	 * @expectedException \InvalidArgumentException
 	 */

--- a/tests/Exception/TranslationLogicExceptionTest.php
+++ b/tests/Exception/TranslationLogicExceptionTest.php
@@ -69,4 +69,12 @@ class TranslationLogicExceptionTest extends \PHPUnit_Framework_TestCase
 	{
 		throw new TranslationLogicException;
 	}
+
+	/**
+	 * @expectedException \LogicException
+	 */
+	public function testExceptionIsLogicException()
+	{
+		throw new TranslationLogicException;
+	}
 }

--- a/tests/Exception/TranslationLogicExceptionTest.php
+++ b/tests/Exception/TranslationLogicExceptionTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Message\Cog\Test\Event;
+
+use Message\Cog\Exception\TranslationLogicException;
+
+class TranslationLogicExceptionTest extends \PHPUnit_Framework_TestCase
+{
+	public function testGetTranslationFromConstruct()
+	{
+		$translation = 'translation';
+		$exception = new TranslationLogicException('Message', $translation);
+		$this->assertSame($translation, $exception->getTranslation());
+	}
+
+	public function testGetTranslationFromSetTranslation()
+	{
+		$translation = 'translation';
+		$exception = new TranslationLogicException('Message');
+		$exception->setTranslation($translation);
+		$this->assertSame($translation, $exception->getTranslation());
+	}
+
+	public function testGetTranslationDefaultToMessage()
+	{
+		$message = 'Message';
+		$exception = new TranslationLogicException($message);
+		$this->assertSame($message, $exception->getTranslation());
+	}
+
+	public function testSetTranslationOverrideConstruct()
+	{
+		$translation = 'override';
+		$exception = new TranslationLogicException('Message', 'original');
+		$exception->setTranslation($translation);
+		$this->assertSame($translation, $exception->getTranslation());
+	}
+
+	public function testSetTranslationOverrideSetTranslation()
+	{
+		$translation = 'override';
+		$exception = new TranslationLogicException('Message');
+		$exception->setTranslation('original');
+		$exception->setTranslation($translation);
+		$this->assertSame($translation, $exception->getTranslation());
+	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 */
+	public function testSetTranslationInvalidTypeFromConstruct()
+	{
+			new TranslationLogicException('Message', []);
+	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 */
+	public function testSetTranslationInvalidTypeFromSetTranslation()
+	{
+		$exception = new TranslationLogicException('Message');
+		$exception->setTranslation([]);
+	}
+}

--- a/tests/Exception/TranslationLogicExceptionTest.php
+++ b/tests/Exception/TranslationLogicExceptionTest.php
@@ -61,4 +61,12 @@ class TranslationLogicExceptionTest extends \PHPUnit_Framework_TestCase
 		$exception = new TranslationLogicException('Message');
 		$exception->setTranslation([]);
 	}
+
+	/**
+	 * @expectedException \Message\Cog\Exception\TranslationLogicException
+	 */
+	public function testExceptionThrowable()
+	{
+		throw new TranslationLogicException;
+	}
 }

--- a/tests/Exception/TranslationRuntimeExceptionTest.php
+++ b/tests/Exception/TranslationRuntimeExceptionTest.php
@@ -62,4 +62,12 @@ class TranslationRuntimeExceptionTest extends \PHPUnit_Framework_TestCase
 		$exception = new TranslationRuntimeException('Message');
 		$exception->setTranslation([]);
 	}
+
+	/**
+	 * @expectedException \Message\Cog\Exception\TranslationRuntimeException
+	 */
+	public function testExceptionThrowable()
+	{
+		throw new TranslationRuntimeException;
+	}
 }

--- a/tests/Exception/TranslationRuntimeExceptionTest.php
+++ b/tests/Exception/TranslationRuntimeExceptionTest.php
@@ -70,4 +70,12 @@ class TranslationRuntimeExceptionTest extends \PHPUnit_Framework_TestCase
 	{
 		throw new TranslationRuntimeException;
 	}
+
+	/**
+	 * @expectedException \RuntimeException
+	 */
+	public function testExceptionIsRuntimeException()
+	{
+		throw new TranslationRuntimeException;
+	}
 }

--- a/tests/Exception/TranslationRuntimeExceptionTest.php
+++ b/tests/Exception/TranslationRuntimeExceptionTest.php
@@ -45,6 +45,45 @@ class TranslationRuntimeExceptionTest extends \PHPUnit_Framework_TestCase
 		$this->assertSame($translation, $exception->getTranslation());
 	}
 
+	public function testGetParamsFromConstruct()
+	{
+		$params = ['foo' => 'bar'];
+		$exception = new TranslationRuntimeException('Message', 'translation', $params);
+		$this->assertSame($params, $exception->getParams());
+	}
+
+	public function testGetParamsFromSetParams()
+	{
+		$params = ['foo' => 'bar'];
+		$exception = new TranslationRuntimeException('Message');
+		$exception->setParams($params);
+		$this->assertSame($params, $exception->getParams());
+	}
+
+	public function testGetParamsDefaultToEmptyArray()
+	{
+		$exception = new TranslationRuntimeException;
+		$this->assertSame([], $exception->getParams());
+	}
+
+	public function testSetParamsOverrideConstruct()
+	{
+		$params = ['baz' => 'bing'];
+		$exception = new TranslationRuntimeException('Message', 'translation', ['foo' => 'bar']);
+		$exception->setParams($params);
+		$this->assertSame($params, $exception->getParams());
+	}
+
+	public function testSetParamsOverrideSetParams()
+	{
+		$params = ['baz' => 'bing'];
+		$exception = new TranslationRuntimeException;
+		$exception->setParams(['foo' => 'bar']);
+		$exception->setParams($params);
+		$this->assertSame($params, $exception->getParams());
+	}
+
+
 	/**
 	 * @expectedException \InvalidArgumentException
 	 */

--- a/tests/Exception/TranslationRuntimeExceptionTest.php
+++ b/tests/Exception/TranslationRuntimeExceptionTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Message\Cog\Test\Event;
+
+use Message\Cog\Exception\TranslationRuntimeException;
+
+class TranslationRuntimeExceptionTest extends \PHPUnit_Framework_TestCase
+{
+	public function testGetTranslationFromConstruct()
+	{
+		$translation = 'translation';
+		$exception = new TranslationRuntimeException('Message', $translation);
+		$this->assertSame($translation, $exception->getTranslation());
+	}
+
+	public function testGetTranslationFromSetTranslation()
+	{
+		$translation = 'translation';
+		$exception = new TranslationRuntimeException('Message');
+		$exception->setTranslation($translation);
+		$this->assertSame($translation, $exception->getTranslation());
+	}
+
+	public function testGetTranslationDefaultToMessage()
+	{
+		$message = 'Message';
+		$exception = new TranslationRuntimeException($message);
+		$this->assertSame($message, $exception->getTranslation());
+	}
+
+	public function testSetTranslationOverrideConstruct()
+	{
+		$translation = 'override';
+		$exception = new TranslationRuntimeException('Message', 'original');
+		$exception->setTranslation($translation);
+		$this->assertSame($translation, $exception->getTranslation());
+	}
+
+	public function testSetTranslationOverrideSetTranslation()
+	{
+		$translation = 'override';
+		$exception = new TranslationRuntimeException('Message');
+		$exception->setTranslation('original');
+		$exception->setTranslation($translation);
+		$this->assertSame($translation, $exception->getTranslation());
+	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 */
+	public function testSetTranslationInvalidTypeFromConstruct()
+	{
+		new TranslationRuntimeException('Message', []);
+	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 */
+	public function testSetTranslationInvalidTypeFromSetTranslation()
+	{
+		$translation = null;
+		$exception = new TranslationRuntimeException('Message');
+		$exception->setTranslation([]);
+	}
+}


### PR DESCRIPTION
This PR adds exception classes to a new `Exception` namespace that can take translation strings to be used when rendering user-facing error messages.

These exceptions both implement a new `TranslationExceptionInterface` and use a `TranslationExceptionTrait`. The classes are identical, except they extend different base exceptions:

+ `TranslationLogicException` extends `\LogicException`
+ `TranslationRuntimeException` extends `\RuntimeException`