### PR TITLE
Rethrow exception if caught in task

### DIFF
--- a/src/Console/Task/Task.php
+++ b/src/Console/Task/Task.php
@@ -81,6 +81,7 @@ abstract class Task extends Command
 
 		$exception = '';
 		$returned  = '';
+		$e = null;
 
 		ob_start(); // capture any calls to `echo` or `print`
 		try {
@@ -95,6 +96,10 @@ abstract class Task extends Command
 				$this->getBuffer(), $printed, $returned, $exception
 			)));
 			$handler->process(array($all, $this->getBuffer(), $printed, $returned, $exception));
+		}
+
+		if ($e instanceof \Exception) {
+			throw $e;
 		}
 	}
 


### PR DESCRIPTION
Exceptions get caught and you don't get to see them when running a task in the console, as a result of https://github.com/mothership-ec/cog/pull/474

This PR will rethrow the exception after it has handled it