### PR TITLE
Added debug log global function

### DIFF
--- a/src/Application/Loader.php
+++ b/src/Application/Loader.php
@@ -51,6 +51,17 @@ namespace {
 	{
 		return de(\Message\Cog\Service\Container::get('db.connection')->getQueryList());
 	}
+
+	function l($message, $context = [])
+	{
+		$message = var_export($message, true);
+
+		$logger = new \Monolog\Logger('debug');
+
+		$logger->pushHandler(new \Message\Cog\Logging\TouchingStreamHandler('cog://logs/debug.log'));
+
+		$logger->debug($message, $context);
+	}
 }
 
 namespace Message\Cog\Application {

--- a/src/Application/Loader.php
+++ b/src/Application/Loader.php
@@ -52,6 +52,14 @@ namespace {
 		return de(\Message\Cog\Service\Container::get('db.connection')->getQueryList());
 	}
 
+	/**
+	 * Short function to debug log objects to `cog://logs/debug.log`
+	 * 
+	 * @see \Psr\Log\LoggerInterface::debug()
+	 * 
+	 * @param  mixed $message Any object to be printed to the log file
+	 * @param  array $context Array context for the message
+	 */
 	function l($message, $context = [])
 	{
 		$message = var_export($message, true);

--- a/src/Application/Loader.php
+++ b/src/Application/Loader.php
@@ -57,7 +57,6 @@ namespace {
 		$message = var_export($message, true);
 
 		$logger = new \Monolog\Logger('debug');
-
 		$logger->pushHandler(new \Message\Cog\Logging\TouchingStreamHandler('cog://logs/debug.log'));
 
 		$logger->debug($message, $context);

--- a/src/Application/Loader.php
+++ b/src/Application/Loader.php
@@ -62,7 +62,7 @@ namespace {
 	 */
 	function l($message, $context = [])
 	{
-		$message = var_export($message, true);
+		$message = print_r($message, true);
 
 		$logger = new \Monolog\Logger('debug');
 		$logger->pushHandler(new \Message\Cog\Logging\TouchingStreamHandler('cog://logs/debug.log'));

--- a/src/Application/Loader.php
+++ b/src/Application/Loader.php
@@ -57,17 +57,18 @@ namespace {
 	 * 
 	 * @see \Psr\Log\LoggerInterface::debug()
 	 * 
-	 * @param  mixed $message Any object to be printed to the log file
-	 * @param  array $context Array context for the message
+	 * @param mixed $var,... Unlimited number of variables to log
 	 */
-	function l($message, $context = [])
+	function l()
 	{
-		$message = print_r($message, true);
-
 		$logger = new \Monolog\Logger('debug');
 		$logger->pushHandler(new \Message\Cog\Logging\TouchingStreamHandler('cog://logs/debug.log'));
 
-		$logger->debug($message, $context);
+		foreach (func_get_args() as $message) {
+			$message = print_r($message, true);
+
+			$logger->debug($message);
+		}
 	}
 }
 


### PR DESCRIPTION
This will be useful for any live debugging that needs to happen. Using d() and de() is awkward as they are not silent and may cause the site users inconvenience.

Use by calling `l($message)`. Use `tail -f logs/debug.log` to view the output.