### PR TITLE
Form constraints for Vimeo and YouTube

### DIFF
--- a/src/Form/Constraint/Vimeo.php
+++ b/src/Form/Constraint/Vimeo.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Message\Cog\Form\Constraint;
+
+use Symfony\Component\Validator;
+
+class Vimeo extends Validator\Constraints\Url
+{
+}

--- a/src/Form/Constraint/Vimeo.php
+++ b/src/Form/Constraint/Vimeo.php
@@ -4,6 +4,15 @@ namespace Message\Cog\Form\Constraint;
 
 use Symfony\Component\Validator;
 
+/**
+ * Class Vimeo
+ * @package Message\Cog\Form\Constraint
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ *          
+ * Constraint for validating Vimeo URLs in forms
+ */
 class Vimeo extends Validator\Constraints\Url
 {
+
 }

--- a/src/Form/Constraint/VimeoValidator.php
+++ b/src/Form/Constraint/VimeoValidator.php
@@ -57,5 +57,7 @@ class VimeoValidator extends Validator\Constraints\UrlValidator
 		if (strlen($code) > self::CODE_LENGTH) {
 			return false;
 		}
+
+		return true;
 	}
 }

--- a/src/Form/Constraint/VimeoValidator.php
+++ b/src/Form/Constraint/VimeoValidator.php
@@ -22,6 +22,8 @@ class VimeoValidator extends Validator\Constraints\UrlValidator
 	 */
 	public function validate($value, Validator\Constraint $constraint)
 	{
+		// If value has not been submitting, it should skip validation. However, we cannot simply check for
+		// falsiness because the value could be '0' (spoiler alert: that will fail validation)
 		if (null === $value || false === $value || '' === $value) {
 			return;
 		}

--- a/src/Form/Constraint/VimeoValidator.php
+++ b/src/Form/Constraint/VimeoValidator.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Message\Cog\Form\Constraint;
+
+use Symfony\Component\Validator;
+
+class VimeoValidator extends Validator\Constraints\UrlValidator
+{
+	const URL_MATCH         = 'vimeo.com';
+	const CODE_LENGTH       = 15;
+	const ERROR_MESSAGE     = '\'%value%\' is not a valid Vimeo URL';
+	const VALUE_KEY         = '%value%';
+
+	public function validate($value, Validator\Constraint $constraint)
+	{
+		if (empty($value)) {
+			return true;
+		}
+
+		if (strpos($value, self::URL_MATCH) === false) {
+			$this->context->addViolation(self::ERROR_MESSAGE, [self::VALUE_KEY => $value]);
+			return false;
+		}
+
+		$parts = explode('/', $value);
+
+		$code  = array_pop($parts);
+
+		if (strlen($code) > self::CODE_LENGTH) {
+			$this->context->addViolation(self::ERROR_MESSAGE, [self::VALUE_KEY => $value]);
+		}
+	}
+}

--- a/src/Form/Constraint/VimeoValidator.php
+++ b/src/Form/Constraint/VimeoValidator.php
@@ -4,6 +4,12 @@ namespace Message\Cog\Form\Constraint;
 
 use Symfony\Component\Validator;
 
+/**
+ * Class VimeoValidator
+ * @package Message\Cog\Form\Constraint
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ */
 class VimeoValidator extends Validator\Constraints\UrlValidator
 {
 	const URL_MATCH         = 'vimeo.com';
@@ -11,23 +17,45 @@ class VimeoValidator extends Validator\Constraints\UrlValidator
 	const ERROR_MESSAGE     = '\'%value%\' is not a valid Vimeo URL';
 	const VALUE_KEY         = '%value%';
 
+	/**
+	 * {@inheritDoc}
+	 */
 	public function validate($value, Validator\Constraint $constraint)
 	{
-		if (empty($value)) {
-			return true;
+		if (null === $value || false === $value || '' === $value) {
+			return;
 		}
 
-		if (strpos($value, self::URL_MATCH) === false) {
+		parent::validate($value, $constraint);
+
+		if (!$this->_isValid($value)) {
 			$this->context->addViolation(self::ERROR_MESSAGE, [self::VALUE_KEY => $value]);
+		}
+	}
+
+	/**
+	 * Check if the value is a valid Vimeo URL
+	 *
+	 * @param $url
+	 *
+	 * @return bool
+	 */
+	private function _isValid($url)
+	{
+		if (strpos($url, self::URL_MATCH) === false) {
 			return false;
 		}
 
-		$parts = explode('/', $value);
+		$parts = explode('/', $url);
 
 		$code  = array_pop($parts);
 
+		if (!is_numeric($code)) {
+			return false;
+		}
+
 		if (strlen($code) > self::CODE_LENGTH) {
-			$this->context->addViolation(self::ERROR_MESSAGE, [self::VALUE_KEY => $value]);
+			return false;
 		}
 	}
 }

--- a/src/Form/Constraint/Youtube.php
+++ b/src/Form/Constraint/Youtube.php
@@ -6,7 +6,7 @@ use Symfony\Component\Validator\Constraints\Url as BaseConstraint;
 
 /**
  * Class Youtube
- * @package Mothership\Site\Constraint
+ * @package Message\Cog\Form\Constraint
  *
  * @author  Thomas Marchant <thomas@mothership.ec>
  *

--- a/src/Form/Constraint/Youtube.php
+++ b/src/Form/Constraint/Youtube.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Message\Cog\Form\Constraint;
+
+use Symfony\Component\Validator\Constraints\Url as BaseConstraint;
+
+/**
+ * Class Youtube
+ * @package Mothership\Site\Constraint
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ *
+ * Constraint for validating YouTube URLs in forms
+ */
+class Youtube extends BaseConstraint
+{
+
+}

--- a/src/Form/Constraint/YoutubeValidator.php
+++ b/src/Form/Constraint/YoutubeValidator.php
@@ -6,11 +6,9 @@ use Symfony\Component\Validator;
 
 /**
  * Class YoutubeValidator
- * @package Mothership\Site\Constraint
+ * @package Message\Cog\Form\Constraint
  *
  * @author  Thomas Marchant <thomas@mothership.ec>
- *
- * Validator for Youtube constraint
  */
 class YoutubeValidator extends Validator\Constraints\UrlValidator
 {
@@ -24,8 +22,8 @@ class YoutubeValidator extends Validator\Constraints\UrlValidator
 	 */
 	public function validate($value, Validator\Constraint $constraint)
 	{
-		if (empty($value)) {
-			return true;
+		if (null === $value || false === $value || '' === $value) {
+			return;
 		}
 
 		parent::validate($value, $constraint);
@@ -34,12 +32,12 @@ class YoutubeValidator extends Validator\Constraints\UrlValidator
 			$this->context->addViolation('\'%value%\' is not a valid YouTube video URL', [
 				'%value%' => $value,
 			]);
-
-			return false;
 		}
 	}
 
 	/**
+	 * Check if the value is a valid YouTube URL
+	 *
 	 * @param $url
 	 *
 	 * @return bool

--- a/src/Form/Constraint/YoutubeValidator.php
+++ b/src/Form/Constraint/YoutubeValidator.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Message\Cog\Form\Constraint;
+
+use Symfony\Component\Validator;
+
+/**
+ * Class YoutubeValidator
+ * @package Mothership\Site\Constraint
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ *
+ * Validator for Youtube constraint
+ */
+class YoutubeValidator extends Validator\Constraints\UrlValidator
+{
+	const URL_MATCH         = 'youtu';
+	const CODE_LENGTH       = 11;
+	const ERROR_MESSAGE     = '\'%value%\' is not a valid Vimeo URL';
+	const VALUE_KEY         = '%value%';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function validate($value, Validator\Constraint $constraint)
+	{
+		if (empty($value)) {
+			return true;
+		}
+
+		parent::validate($value, $constraint);
+
+		if (!$this->_isValid($value)) {
+			$this->context->addViolation('\'%value%\' is not a valid YouTube video URL', [
+				'%value%' => $value,
+			]);
+
+			return false;
+		}
+	}
+
+	/**
+	 * @param $url
+	 *
+	 * @return bool
+	 */
+	private function _isValid($url)
+	{
+		if (!strstr($url, self::URL_MATCH)) {
+			return false;
+		}
+
+		// Check if short hand URL
+		if (preg_match('/^https?:\/\/youtu.be\/[A-Za-z0-9\-_]{11}$/', $url)) {
+			return true;
+		}
+
+		$urn = explode('/', $url);
+		$urn = array_pop($urn);
+		parse_str($urn, $parts);
+
+		if (!array_key_exists('watch?v', $parts) || (strlen($parts['watch?v']) !== self::CODE_LENGTH)) {
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/src/Form/Constraint/YoutubeValidator.php
+++ b/src/Form/Constraint/YoutubeValidator.php
@@ -22,6 +22,8 @@ class YoutubeValidator extends Validator\Constraints\UrlValidator
 	 */
 	public function validate($value, Validator\Constraint $constraint)
 	{
+		// If value has not been submitting, it should skip validation. However, we cannot simply check for
+		// falsiness because the value could be '0' (spoiler alert: that will fail validation)
 		if (null === $value || false === $value || '' === $value) {
 			return;
 		}
@@ -57,6 +59,7 @@ class YoutubeValidator extends Validator\Constraints\UrlValidator
 		$urn = array_pop($urn);
 		parse_str($urn, $parts);
 
+		// Check that video ID exists in the URL and is the correct length
 		if (!array_key_exists('watch?v', $parts) || (strlen($parts['watch?v']) !== self::CODE_LENGTH)) {
 			return false;
 		}


### PR DESCRIPTION
This PR adds a new namespace for custom Symfony constraints. They are directly in the form component to avoid confusion with the deprecated `Validation` component, since they are realistically only used on forms anyway.

Annoyingly, they can't really be unit tested because they are extensions of Symfony's own classes, so it might be an idea to abstract the actual validation to something else, but I'm not sure where a good place for that would be.