### PR TITLE
Add check string method to validator trait

### DIFF
--- a/src/Helper/ValidatorTrait.php
+++ b/src/Helper/ValidatorTrait.php
@@ -72,7 +72,7 @@ trait ValidatorTrait
 		}
 
 		if (!$allowEmpty && !$x) {
-			throw new InvalidVariableException($name . ' must not be empty');
+			throw new InvalidVariableException($name . ' must be a non-empty string');
 		}
 	}
 

--- a/src/Helper/ValidatorTrait.php
+++ b/src/Helper/ValidatorTrait.php
@@ -59,6 +59,25 @@ trait ValidatorTrait
 
 	/**
 	 * @param $x
+	 * @param string $name
+	 * @param bool $allowEmpty
+	 * @throws InvalidVariableException
+	 */
+	public function checkString($x, $allowEmpty = false, $name = 'Value')
+	{
+		$this->_validateVarName($name);
+
+		if (!is_string($x)) {
+			throw new InvalidVariableException($name . ' should be a ' . ($allowEmpty ? '' : 'non-empty ') . 'string, ' . gettype($x) . ' given');
+		}
+
+		if (!$allowEmpty && !$x) {
+			throw new InvalidVariableException($name . ' must not be empty');
+		}
+	}
+
+	/**
+	 * @param $x
 	 * @param $class
 	 * @param string | object $name
 	 * @throws InvalidVariableException

--- a/tests/Helper/ValidatorTraitTest.php
+++ b/tests/Helper/ValidatorTraitTest.php
@@ -140,6 +140,55 @@ class ValidatorTraitTest extends \PHPUnit_Framework_TestCase
 		$this->_foo->checkScalar(true, []);
 	}
 
+	public function testCheckString()
+	{
+		$this->_foo->checkString('foo');
+		$this->_foo->checkString('foo', true);
+	}
+
+	/**
+	 * @expectedException \Message\Cog\Exception\InvalidVariableException
+	 */
+	public function testCheckStringWithEmpty()
+	{
+		$this->_foo->checkString('');
+	}
+
+	public function testCheckStringWithEmptyAllowEmpty()
+	{
+		$this->_foo->checkString('', true);
+	}
+
+	/**
+	 * @expectedException \Message\Cog\Exception\InvalidVariableException
+	 */
+	public function testCheckStringWithNonString()
+	{
+		$this->_foo->checkString(true);
+	}
+
+
+	/**
+	 * @expectedException \Message\Cog\Exception\InvalidVariableException
+	 */
+	public function testCheckStringWithNonStringAllowEmpty()
+	{
+		$this->_foo->checkString(false);
+	}
+
+	public function testCheckStringWithValidName()
+	{
+		$this->_foo->checkString('string', false, 'Foo');
+	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 */
+	public function testCheckStringWithInvalidName()
+	{
+		$this->_foo->checkString('string', false, []);
+	}
+
 	public function testCheckInstanceAgainstClassName()
 	{
 		$this->_foo->checkInstance(new \stdClass, '\\stdClass');

--- a/tests/Helper/ValidatorTraitTest.php
+++ b/tests/Helper/ValidatorTraitTest.php
@@ -167,13 +167,12 @@ class ValidatorTraitTest extends \PHPUnit_Framework_TestCase
 		$this->_foo->checkString(true);
 	}
 
-
 	/**
 	 * @expectedException \Message\Cog\Exception\InvalidVariableException
 	 */
 	public function testCheckStringWithNonStringAllowEmpty()
 	{
-		$this->_foo->checkString(false);
+		$this->_foo->checkString(false, true);
 	}
 
 	public function testCheckStringWithValidName()


### PR DESCRIPTION
When building https://github.com/mothership-ec/cog/pull/488 I originally added a `checkString()` method, but then swapped it out to the `checkScalar()` method. THING IS, I actually do want a `checkString()` method, so I've added one